### PR TITLE
Refactor status tracking configuration

### DIFF
--- a/config/tool_execution.ts
+++ b/config/tool_execution.ts
@@ -19,6 +19,15 @@ export const EXCLUDED_FROM_TIMEOUT_FUNCTIONS = new Set([
 ]);
 
 /**
+ * Tools that enable background status tracking for timeouts
+ */
+export const STATUS_TRACKING_TOOLS = new Set([
+    'get_running_tools',
+    'wait_for_running_tool',
+    'get_tool_status',
+]);
+
+/**
  * Maximum length for tool results before summarization
  */
 export const MAX_RESULT_LENGTH = 1000;

--- a/docs/tool-execution.md
+++ b/docs/tool-execution.md
@@ -188,6 +188,12 @@ export const EXCLUDED_FROM_TIMEOUT_FUNCTIONS = new Set([
     // Add your tools here
 ]);
 
+export const STATUS_TRACKING_TOOLS = new Set([
+    'get_running_tools',
+    'wait_for_running_tool',
+    'get_tool_status',
+]);
+
 export const SKIP_SUMMARIZATION_TOOLS = new Set([
     'read_source',
     'get_page_content',
@@ -333,7 +339,7 @@ const result3 = await runSequential('agent-2', async () => {
 
 ## Best Practices
 
-1. **Enable Status Tracking**: Include status tracking tools (`get_running_tools`, `wait_for_running_tool`) to enable timeout handling.
+1. **Enable Status Tracking**: Include any tool listed in `STATUS_TRACKING_TOOLS` to enable timeout handling.
 
 2. **Use Sequential Execution Carefully**: Only enable sequential execution when tools have dependencies or shared state.
 

--- a/utils/tool_execution_manager.ts
+++ b/utils/tool_execution_manager.ts
@@ -11,6 +11,7 @@ import { coerceValue } from './tool_parameter_utils.js';
 import {
     FUNCTION_TIMEOUT_MS,
     EXCLUDED_FROM_TIMEOUT_FUNCTIONS,
+    STATUS_TRACKING_TOOLS,
 } from '../config/tool_execution.js';
 
 /**
@@ -28,14 +29,8 @@ export function timeoutPromise(ms: number): Promise<'TIMEOUT'> {
 export function agentHasStatusTracking(agent: AgentDefinition): boolean {
     if (!agent.tools) return false;
 
-    const statusTrackingTools = [
-        'get_running_tools',
-        'wait_for_running_tool',
-        'get_tool_status',
-    ];
-
     return agent.tools.some(tool =>
-        statusTrackingTools.includes(tool.definition.function.name)
+        STATUS_TRACKING_TOOLS.has(tool.definition.function.name)
     );
 }
 


### PR DESCRIPTION
## Summary
- centralize status tracking tool names in `STATUS_TRACKING_TOOLS`
- reuse constant in `agentHasStatusTracking`
- document new constant in tool execution guide

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841c9709ee0832a8d0a375df1ddea15