### PR TITLE
feat: add unified failure detection flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ console.log('Validation Result:', {
 ## Documentation
 
 - [Tool Execution Guide](docs/tool-execution.md) - Advanced tool calling features
+- [Failure Detection](docs/failure-detection.md) - Unified request/image failure signaling and fail-fast aggregation
 - [Interactive Demos](demo/) - Web-based demos for core features
 - Generated [API Reference](docs/api) with `npm run docs`
   

--- a/core/ensemble_image.ts
+++ b/core/ensemble_image.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { AgentDefinition, ImageGenerationOpts, ProviderStreamEvent } from '../types/types.js';
 import { getModelFromAgent, getModelProvider } from '../model_providers/model_provider.js';
 import { createTraceContext } from '../utils/trace_context.js';
+import { createOperationStatusEvent, raceWithAbortAndTimeout, toTerminalErrorEvent } from '../utils/failure_detection.js';
 
 /**
  * Generate images from text prompts
@@ -56,7 +57,14 @@ export function ensembleImage(
             });
             requestStarted = true;
 
-            const images = await provider.createImage(prompt, model, agent, requestOptions);
+            const images = await raceWithAbortAndTimeout(
+                () => provider.createImage!(prompt, model, agent, requestOptions),
+                {
+                    operationName: `Image generation for ${model}`,
+                    abortSignal: agent.abortSignal,
+                    timeoutMs: requestOptions.timeout_ms,
+                }
+            );
             await trace.emitRequestEnd(tracedRequestId, {
                 status: 'completed',
                 image_count: images.length,
@@ -89,6 +97,13 @@ export function ensembleImage(
 
         // Emit start
         yield { type: 'image_start', request_id, timestamp: new Date().toISOString() } as ProviderStreamEvent;
+        yield createOperationStatusEvent({
+            operation: 'image',
+            status: 'started',
+            request_id,
+            will_continue: true,
+            terminal: false,
+        }) as ProviderStreamEvent;
 
         // Bridge cost updates for this request_id only
         const handler = (usage: any) => {
@@ -128,11 +143,29 @@ export function ensembleImage(
 
             // Final image_complete
             yield { type: 'image_complete', request_id, timestamp: new Date().toISOString() } as ProviderStreamEvent;
+            yield createOperationStatusEvent({
+                operation: 'image',
+                status: 'completed',
+                request_id,
+                terminal: true,
+                will_continue: false,
+            }) as ProviderStreamEvent;
 
             // Flush residual cost events
             while (iterator.queue.length) yield iterator.queue.shift() as ProviderStreamEvent;
         } catch (error: any) {
-            yield { type: 'error', request_id, error: String(error?.message || error) } as ProviderStreamEvent;
+            const errorMessage = String(error?.message || error);
+            yield createOperationStatusEvent({
+                operation: 'image',
+                status: 'failed',
+                request_id,
+                error: errorMessage,
+                recoverable: false,
+                terminal: true,
+                will_continue: false,
+                reason: 'provider_error',
+            }) as ProviderStreamEvent;
+            yield toTerminalErrorEvent({ request_id, error: errorMessage }) as ProviderStreamEvent;
         } finally {
             // remove listener
             costTracker.offAddUsage(handler);

--- a/core/ensemble_request.ts
+++ b/core/ensemble_request.ts
@@ -30,9 +30,36 @@ import {
     convertToFunctionCallOutput,
 } from '../utils/message_converter.js';
 import { truncateLargeValues } from '../utils/truncate_utils.js';
+import { createOperationStatusEvent, streamWithAbortAndTimeout, toTerminalErrorEvent } from '../utils/failure_detection.js';
+import { validateJsonResponseContent } from '../utils/json_schema.js';
+import { runningToolTracker } from '../utils/running_tool_tracker.js';
 
 const MAX_ERROR_ATTEMPTS = 5;
 const DEFAULT_TERMINAL_TOOL_NAMES = new Set(['task_complete', 'task_fatal_error']);
+const TOOL_FAILURE_FINALIZATION_TIMEOUT_MS = 50;
+
+const isTerminalRoundError = (error: unknown): boolean => {
+    const candidate = error as {
+        recoverable?: boolean;
+        code?: string;
+        name?: string;
+        message?: string;
+    };
+
+    if (candidate?.recoverable === false) {
+        return true;
+    }
+
+    if (candidate?.code === 'ETIMEDOUT' || candidate?.code === 'ABORT_ERR') {
+        return true;
+    }
+
+    if (candidate?.name === 'AbortError') {
+        return true;
+    }
+
+    return false;
+};
 
 const getTerminalToolNames = (agent: AgentDefinition): Set<string> => {
     const toolNames = new Set(DEFAULT_TERMINAL_TOOL_NAMES);
@@ -42,6 +69,14 @@ const getTerminalToolNames = (agent: AgentDefinition): Set<string> => {
         }
     }
     return toolNames;
+};
+
+const hasTerminalTextContent = (content: unknown, expectsStructuredOutput: boolean): content is string => {
+    if (typeof content !== 'string') {
+        return false;
+    }
+
+    return expectsStructuredOutput ? content.trim().length > 0 : content.length > 0;
 };
 
 // Set the ensemble request function in verification and image-to-text modules to avoid circular dependency
@@ -105,8 +140,13 @@ export async function* ensembleRequest(
     const maxRounds = agent?.maxToolCallRoundsPerTurn ?? Infinity;
     let hasToolCalls = false;
     let hasError = false;
+    let terminalErrorThisRound = false;
     let lastMessageContent = '';
+    const expectsStructuredOutput = Boolean(agent.modelSettings?.json_schema?.schema);
     const modelHistory: string[] = [];
+    let lifecycleRequestId: string | undefined;
+    let lastRoundRequestId: string | undefined;
+    let requestStartedStatusEmitted = false;
 
     await trace.emitTurnStart({
         input_messages: conversationHistory,
@@ -117,6 +157,7 @@ export async function* ensembleRequest(
         do {
             hasToolCalls = false;
             hasError = false;
+            terminalErrorThisRound = false;
             let terminalToolSucceededThisRound = false;
             let currentRoundRequestId: string | undefined;
             const currentRoundMessages: string[] = [];
@@ -125,6 +166,8 @@ export async function* ensembleRequest(
             let currentRoundRequestDuration: number | undefined;
             let currentRoundDurationWithTools: number | undefined;
             let currentRoundRequestCost: number | undefined;
+            let currentRoundLimitError: string | undefined;
+            const deferredTerminalErrors: ProviderStreamEvent[] = [];
             const terminalToolNames = getTerminalToolNames(agent);
 
             const model = await getModelFromAgent(
@@ -135,22 +178,58 @@ export async function* ensembleRequest(
             modelHistory.push(model);
 
             // Execute one round
-            const stream = executeRound(model, agent, history, totalToolCalls, maxToolCalls, trace);
+            const stream = executeRound(
+                model,
+                agent,
+                history,
+                totalToolCalls,
+                maxToolCalls,
+                trace,
+                !requestStartedStatusEmitted
+            );
 
             // Yield all events from this round
             try {
                 for await (const event of stream) {
-                    yield event;
+                    let normalizedEvent = event;
+                    if (normalizedEvent.type === 'error' && currentRoundToolCalls > 0) {
+                        const errorEvent = normalizedEvent as any;
+                        if (errorEvent.recoverable !== false) {
+                            normalizedEvent = {
+                                ...errorEvent,
+                                recoverable: false,
+                            } as ProviderStreamEvent;
+                        }
+                    }
 
-                    switch (event.type) {
+                    const isDeferredTerminalError =
+                        normalizedEvent.type === 'error' && (normalizedEvent as any).recoverable === false;
+
+                    if (isDeferredTerminalError) {
+                        deferredTerminalErrors.push(normalizedEvent);
+                    } else {
+                        yield normalizedEvent;
+                    }
+
+                    switch (normalizedEvent.type) {
                         case 'agent_start': {
-                            currentRoundRequestId = event.request_id;
+                            currentRoundRequestId = normalizedEvent.request_id;
+                            lastRoundRequestId = normalizedEvent.request_id;
+                            lifecycleRequestId ??= normalizedEvent.request_id;
+                            break;
+                        }
+
+                        case 'operation_status': {
+                            const statusEvent = normalizedEvent as any;
+                            if (statusEvent.operation === 'request' && statusEvent.status === 'started') {
+                                requestStartedStatusEmitted = true;
+                            }
                             break;
                         }
 
                         case 'message_complete': {
-                            const messageEvent = event as MessageEventBase;
-                            if (messageEvent.content) {
+                            const messageEvent = normalizedEvent as MessageEventBase;
+                            if (hasTerminalTextContent(messageEvent.content, expectsStructuredOutput)) {
                                 lastMessageContent = messageEvent.content;
                                 currentRoundMessages.push(messageEvent.content);
                             }
@@ -158,12 +237,12 @@ export async function* ensembleRequest(
                         }
 
                         case 'tool_start': {
-                            const toolEvent = event as ToolEvent;
+                            const toolEvent = normalizedEvent as ToolEvent;
                             if (toolEvent.tool_call) {
                                 const toolName = toolEvent.tool_call.function.name;
                                 currentRoundToolCalls += 1;
 
-                                await trace.emitToolStart(event.request_id, toolEvent.tool_call.id, {
+                                await trace.emitToolStart(normalizedEvent.request_id, toolEvent.tool_call.id, {
                                     tool_name: toolName,
                                     arguments: toolEvent.tool_call.function.arguments,
                                     arguments_formatted: toolEvent.tool_call.function.arguments_formatted,
@@ -179,7 +258,7 @@ export async function* ensembleRequest(
                         }
 
                         case 'tool_done': {
-                            const toolEvent = event as ToolEvent;
+                            const toolEvent = normalizedEvent as ToolEvent;
                             if (toolEvent.tool_call) {
                                 const toolName = toolEvent.tool_call.function.name;
                                 if (terminalToolNames.has(toolName) && !toolEvent.result?.error) {
@@ -197,7 +276,7 @@ export async function* ensembleRequest(
                         }
 
                         case 'agent_done': {
-                            const agentDoneEvent = event as any;
+                            const agentDoneEvent = normalizedEvent as any;
                             currentRoundRequestDuration = agentDoneEvent.request_duration;
                             currentRoundDurationWithTools = agentDoneEvent.duration_with_tools;
                             currentRoundRequestCost = agentDoneEvent.request_cost;
@@ -206,7 +285,10 @@ export async function* ensembleRequest(
 
                         case 'error': {
                             hasError = true;
-                            const errorEvent = event as any;
+                            const errorEvent = normalizedEvent as any;
+                            if (errorEvent.recoverable === false) {
+                                terminalErrorThisRound = true;
+                            }
                             if (errorEvent.error) {
                                 currentRoundErrors.push(String(errorEvent.error));
                             }
@@ -216,21 +298,27 @@ export async function* ensembleRequest(
                 }
             } catch (roundError) {
                 hasError = true;
+                terminalErrorThisRound = isTerminalRoundError(roundError);
                 const errorMessage = roundError instanceof Error ? roundError.message : String(roundError);
                 currentRoundErrors.push(errorMessage);
-                yield {
+                const roundErrorEvent = {
                     type: 'error',
                     request_id: currentRoundRequestId,
                     error: errorMessage,
-                    recoverable: true,
+                    recoverable: !terminalErrorThisRound,
                     timestamp: new Date().toISOString(),
                 } as ProviderStreamEvent;
+                if (terminalErrorThisRound) {
+                    deferredTerminalErrors.push(roundErrorEvent);
+                } else {
+                    yield roundErrorEvent;
+                }
             }
 
-            // A successful terminal tool call ends this turn immediately.
+            // A successful terminal tool call ends this turn immediately, but it must not
+            // erase any malformed-tool or stream errors that also occurred in the round.
             if (terminalToolSucceededThisRound) {
                 hasToolCalls = false;
-                hasError = false;
             }
 
             if (hasToolCalls) {
@@ -245,9 +333,18 @@ export async function* ensembleRequest(
                 ++errorRounds;
             }
 
-            const willRetryForError = hasError && errorRounds < MAX_ERROR_ATTEMPTS;
-            const willContinueForTools = hasToolCalls && toolCallRounds < maxRounds && totalToolCalls < maxToolCalls;
+            const willRetryForError = hasError && !terminalErrorThisRound && errorRounds < MAX_ERROR_ATTEMPTS;
+            const willContinueForTools =
+                !hasError && hasToolCalls && toolCallRounds < maxRounds && totalToolCalls < maxToolCalls;
             const willContinue = willRetryForError || willContinueForTools;
+
+            if (hasToolCalls && !willContinueForTools) {
+                if (toolCallRounds >= maxRounds) {
+                    currentRoundLimitError = `Tool call rounds limit reached (${maxRounds}).`;
+                } else if (totalToolCalls >= maxToolCalls) {
+                    currentRoundLimitError = `Tool call limit reached (${maxToolCalls}).`;
+                }
+            }
 
             let requestStatus = 'completed';
             if (hasError) {
@@ -255,6 +352,8 @@ export async function* ensembleRequest(
             } else if (hasToolCalls) {
                 requestStatus = willContinue ? 'waiting_for_followup_request' : 'tool_limit_reached';
             }
+
+            const requestStatusRequestId = lifecycleRequestId ?? currentRoundRequestId;
 
             if (currentRoundRequestId) {
                 await trace.emitRequestEnd(currentRoundRequestId, {
@@ -268,9 +367,51 @@ export async function* ensembleRequest(
                     request_cost: currentRoundRequestCost,
                 });
             }
+
+            if (hasError && requestStatusRequestId) {
+                yield createOperationStatusEvent({
+                    operation: 'request',
+                    status: willContinue ? 'retrying' : 'failed',
+                    request_id: requestStatusRequestId,
+                    error: currentRoundErrors.at(-1),
+                    reason: requestStatus,
+                    recoverable: willContinue,
+                    terminal: !willContinue,
+                    will_continue: willContinue,
+                    attempt: errorRounds,
+                    max_attempts: MAX_ERROR_ATTEMPTS,
+                }) as ProviderStreamEvent;
+            }
+
+            if (!hasError && requestStatusRequestId && currentRoundLimitError) {
+                yield createOperationStatusEvent({
+                    operation: 'request',
+                    status: 'failed',
+                    request_id: requestStatusRequestId,
+                    error: currentRoundLimitError,
+                    reason: requestStatus,
+                    recoverable: false,
+                    terminal: true,
+                    will_continue: false,
+                }) as ProviderStreamEvent;
+            }
+
+            for (const deferredTerminalError of deferredTerminalErrors) {
+                yield deferredTerminalError;
+            }
+
+            if (hasError && !willContinue) {
+                turnStatus = 'error';
+                turnEndReason = terminalErrorThisRound ? 'terminal_error' : 'max_error_attempts_reached';
+                turnError = currentRoundErrors.at(-1);
+            } else if (currentRoundLimitError) {
+                turnStatus = 'error';
+                turnEndReason = toolCallRounds >= maxRounds ? 'max_tool_call_rounds_reached' : 'max_tool_calls_reached';
+                turnError = currentRoundLimitError;
+            }
         } while (
-            (hasError && errorRounds < MAX_ERROR_ATTEMPTS) ||
-            (hasToolCalls && toolCallRounds < maxRounds && totalToolCalls < maxToolCalls)
+            (hasError && !terminalErrorThisRound && errorRounds < MAX_ERROR_ATTEMPTS) ||
+            (!hasError && hasToolCalls && toolCallRounds < maxRounds && totalToolCalls < maxToolCalls)
         );
 
         // If we hit limits, add a notification
@@ -285,19 +426,29 @@ export async function* ensembleRequest(
             turnEndReason = 'max_error_attempts_reached';
         }
 
-        // Perform verification if configured
-        if (agent?.verifier && lastMessageContent) {
-            const verificationResult = await performVerification(
+        // Perform verification only for otherwise successful turns.
+        if (turnStatus === 'completed' && agent?.verifier && lastMessageContent) {
+            const verificationResult = yield* performVerification(
                 agent,
                 lastMessageContent,
                 await history.getMessages()
             );
 
-            if (verificationResult) {
-                // Yield the verification result
-                for await (const event of verificationResult) {
-                    yield event;
-                }
+            if (!verificationResult.passed) {
+                turnStatus = 'error';
+                turnEndReason = 'verification_failed';
+                turnError = verificationResult.error;
+
+                yield createOperationStatusEvent({
+                    operation: 'request',
+                    status: 'failed',
+                    request_id: lifecycleRequestId ?? lastRoundRequestId,
+                    error: turnError,
+                    reason: 'verification_failed',
+                    recoverable: false,
+                    terminal: true,
+                    will_continue: false,
+                }) as ProviderStreamEvent;
             }
         }
     } catch (err) {
@@ -306,15 +457,35 @@ export async function* ensembleRequest(
         turnStatus = 'error';
         turnEndReason = 'exception';
         turnError = error.message || 'Unknown error';
-        yield {
-            type: 'error',
-            error: error.message || 'Unknown error',
+        yield createOperationStatusEvent({
+            operation: 'request',
+            status: 'failed',
+            request_id: lifecycleRequestId ?? lastRoundRequestId,
+            error: turnError,
+            reason: 'exception',
+            recoverable: false,
+            terminal: true,
+            will_continue: false,
+            max_attempts: MAX_ERROR_ATTEMPTS,
+        }) as ProviderStreamEvent;
+        yield toTerminalErrorEvent({
+            error: turnError,
             code: error.code,
             details: error.details,
             recoverable: error.recoverable,
-            timestamp: new Date().toISOString(),
-        } as ProviderStreamEvent;
+        }) as ProviderStreamEvent;
     } finally {
+        if (turnStatus === 'completed') {
+            yield createOperationStatusEvent({
+                operation: 'request',
+                status: 'completed',
+                request_id: lifecycleRequestId ?? lastRoundRequestId,
+                recoverable: false,
+                terminal: true,
+                will_continue: false,
+            }) as ProviderStreamEvent;
+        }
+
         await trace.emitTurnEnd(turnStatus, turnEndReason, {
             error: turnError,
             tool_call_rounds: toolCallRounds,
@@ -339,7 +510,8 @@ async function* executeRound(
     history: MessageHistory,
     currentToolCalls: number,
     maxToolCalls: number,
-    trace: TraceContext
+    trace: TraceContext,
+    emitStartedStatus: boolean
 ): AsyncGenerator<ProviderStreamEvent> {
     // Generate request ID and track timing
     const requestId = randomUUID();
@@ -373,6 +545,16 @@ async function* executeRound(
     // Also emit through global event controller
     await emitEvent(agentStartEvent, agent, model);
 
+    if (emitStartedStatus) {
+        yield createOperationStatusEvent({
+            operation: 'request',
+            status: 'started',
+            request_id: requestId,
+            will_continue: true,
+            terminal: false,
+        }) as ProviderStreamEvent;
+    }
+
     // Allow agent onRequest hook
     if (agent.onRequest) {
         [agent, messages] = await agent.onRequest(agent, messages);
@@ -396,12 +578,24 @@ async function* executeRound(
     });
 
     // Stream the response with retry support if available
-    const stream =
+    const rawStream: AsyncGenerator<ProviderStreamEvent> =
         'createResponseStreamWithRetry' in provider
             ? (provider as any).createResponseStreamWithRetry(messages, model, agent, requestId)
             : provider.createResponseStream(messages, model, agent, requestId);
+    const stream = streamWithAbortAndTimeout<ProviderStreamEvent>(rawStream, {
+        operationName: `Request generation for ${model}`,
+        abortSignal: agent.abortSignal,
+        timeoutMs: agent.modelSettings?.timeout_ms,
+    });
 
-    const toolPromises: Promise<ToolCallResult>[] = [];
+    type TrackedToolExecution = {
+        toolCall: ToolCall;
+        promise: Promise<ToolCallResult>;
+        settled: boolean;
+        result?: ToolCallResult;
+    };
+
+    const toolExecutions: TrackedToolExecution[] = [];
 
     // Map to store formatted arguments for each tool call
     const toolCallFormattedArgs = new Map<string, string>();
@@ -416,218 +610,310 @@ async function* executeRound(
         toolEventBuffer.push(event);
     };
 
-    for await (let event of stream) {
-        // Add request_id to all events from provider
-        event = { ...event, request_id: requestId };
-
-        // Handle tool_start events specially to add formatted arguments
-        if (event.type === 'tool_start') {
-            const toolEvent = event as ToolEvent;
-            if (toolEvent.tool_call) {
-                const toolCall = toolEvent.tool_call;
-
-                // Format arguments to match parameter order if possible
-                let argumentsFormatted: string | undefined;
-                try {
-                    // Find the tool definition to get parameter order
-                    const tool = agent.tools?.find(t => t.definition.function.name === toolCall.function.name);
-
-                    if (tool && 'definition' in tool && tool.definition.function.parameters.properties) {
-                        const parsedArgs = JSON.parse(toolCall.function.arguments || '{}');
-                        if (typeof parsedArgs === 'object' && parsedArgs !== null && !Array.isArray(parsedArgs)) {
-                            // Get parameter names in the correct order
-                            const paramNames = Object.keys(tool.definition.function.parameters.properties);
-
-                            // Create ordered object
-                            const orderedArgs: Record<string, any> = {};
-                            for (const param of paramNames) {
-                                if (param in parsedArgs) {
-                                    orderedArgs[param] = parsedArgs[param];
-                                }
-                            }
-
-                            argumentsFormatted = JSON.stringify(orderedArgs, null, 2);
-                        }
-                    }
-                } catch (error) {
-                    // If formatting fails, we'll just use the original
-                    console.debug('Failed to format tool arguments:', error);
+    const structuredOutputSchema = agent.modelSettings?.json_schema?.strict === true
+        ? agent.modelSettings.json_schema.schema
+        : undefined;
+    let sawTerminalProviderEvent = false;
+    let sawTerminalProviderFailure = false;
+    const finalizeToolResults = async function* (mode: 'wait_all' | 'bounded_failure') {
+        if (mode === 'bounded_failure') {
+            const waitForPendingExecutions = async (executions: TrackedToolExecution[]) => {
+                if (executions.length === 0) {
+                    return;
                 }
 
-                // Store formatted arguments if we have them
-                if (argumentsFormatted) {
-                    toolCallFormattedArgs.set(toolCall.id, argumentsFormatted);
+                await Promise.race([
+                    Promise.all(executions.map(execution => execution.promise.then(() => undefined))),
+                    new Promise(resolve => setTimeout(resolve, TOOL_FAILURE_FINALIZATION_TIMEOUT_MS)),
+                ]);
+            };
+
+            await waitForPendingExecutions(toolExecutions.filter(execution => !execution.settled));
+
+            for (const execution of toolExecutions) {
+                if (execution.settled) {
+                    continue;
                 }
 
-                // Create a modified tool call with formatted arguments for the event
-                const modifiedEvent = {
-                    ...event,
-                    tool_call: {
-                        ...toolCall,
-                        function: {
-                            ...toolCall.function,
-                            arguments_formatted: argumentsFormatted,
-                        },
-                    },
-                };
+                const runningToolId = execution.toolCall.id || execution.toolCall.call_id;
+                if (runningToolId) {
+                    runningToolTracker.abortRunningTool(runningToolId);
+                }
+            }
 
-                // Update event to the modified one for further processing
-                event = modifiedEvent;
+            await waitForPendingExecutions(toolExecutions.filter(execution => !execution.settled));
+
+            for (const execution of toolExecutions) {
+                if (execution.settled) {
+                    continue;
+                }
+
+                execution.settled = true;
+                execution.result = createToolFinalizationFailureResult(execution.toolCall);
             }
         }
 
-        yield event;
+        const toolResults: ToolCallResult[] = mode === 'wait_all'
+            ? await Promise.all(toolExecutions.map(execution => execution.promise))
+            : toolExecutions.flatMap(execution => (execution.settled && execution.result ? [execution.result] : []));
+        const terminalToolNames = getTerminalToolNames(agent);
 
-        // Emit event through global event controller
-        await emitEvent(event, agent, model);
+        for (const toolResult of toolResults) {
+            const toolName = toolResult.toolCall.function.name;
+            const isTerminalTool = terminalToolNames.has(toolName);
 
-        // Handle different event types
-        switch (event.type) {
-            case 'cost_update': {
-                // Accumulate cost from cost_update events
-                const costEvent = event as any;
-                if (costEvent.usage?.cost) {
-                    totalCost += costEvent.usage.cost;
-                }
-                break;
-            }
+            const formattedArgs = toolCallFormattedArgs.get(toolResult.toolCall.id);
+            const toolCallWithFormattedArgs = formattedArgs
+                ? {
+                      ...toolResult.toolCall,
+                      function: {
+                          ...toolResult.toolCall.function,
+                          arguments_formatted: formattedArgs,
+                      },
+                  }
+                : toolResult.toolCall;
 
-            case 'message_complete': {
-                const messageEvent = event as MessageEventBase;
+            const toolDoneEvent: ProviderStreamEvent = {
+                type: 'tool_done',
+                request_id: requestId,
+                tool_call: toolCallWithFormattedArgs,
+                result: {
+                    call_id: toolResult.call_id || toolResult.id,
+                    output: toolResult.output,
+                    error: toolResult.error,
+                },
+            };
+            yield toolDoneEvent;
+            await emitEvent(toolDoneEvent, agent, model);
 
-                // Some providers emit assistant prefill/summary text in the same turn as tool_use.
-                // Persisting that assistant message after tool results can violate provider ordering
-                // constraints on follow-up requests (e.g. Claude requires next request to end on user
-                // tool_result after tool_use). Once a tool call has started in this round, ignore
-                // subsequent assistant message_complete payloads for history construction.
-                if (sawToolCallThisRound) {
-                    break;
-                }
+            if (!isTerminalTool) {
+                const functionOutput = convertToFunctionCallOutput(toolResult, model, 'completed');
 
-                if (
-                    messageEvent.thinking_content ||
-                    (!messageEvent.content && messageEvent.message_id) // Note that some providers require empty thinking nodes to be included in the conversation history
-                ) {
-                    const thinkingMessage = convertToThinkingMessage(messageEvent, model);
-
-                    if (agent.onThinking) {
-                        await agent.onThinking(thinkingMessage);
-                    }
-
-                    history.add(thinkingMessage);
-                    yield {
-                        type: 'response_output',
-                        message: thinkingMessage,
-                        request_id: requestId,
-                    };
-                }
-                if (messageEvent.content) {
-                    const contentMessage = convertToOutputMessage(messageEvent, model, 'completed');
-
-                    if (agent.onResponse) {
-                        await agent.onResponse(contentMessage);
-                    }
-
-                    history.add(contentMessage);
-                    yield {
-                        type: 'response_output',
-                        message: contentMessage,
-                        request_id: requestId,
-                    };
-                }
-                break;
-            }
-
-            case 'tool_start': {
-                const toolEvent = event as ToolEvent;
-                if (!toolEvent.tool_call) {
-                    break;
-                }
-                sawToolCallThisRound = true;
-
-                // Check if we'll exceed the limit
-                const remainingCalls = maxToolCalls - currentToolCalls;
-                if (remainingCalls <= 0) {
-                    console.warn(`Tool call limit reached (${maxToolCalls}). Skipping tool calls.`);
-                    // Don't count this as having tool calls if we're at the limit
-                    break;
-                }
-
-                const toolCall = toolEvent.tool_call;
-
-                // Add function call
-                const functionCall = convertToFunctionCall(toolCall, model, 'completed');
-
-                // Run tools in parallel
-                toolPromises.push(processToolCall(toolCall, agent));
-
-                history.add(functionCall);
-                yield {
+                history.add(functionOutput);
+                const functionOutputEvent: ProviderStreamEvent = {
                     type: 'response_output',
-                    message: functionCall,
+                    message: functionOutput,
                     request_id: requestId,
                 };
-                break;
-            }
-
-            case 'error': {
-                // Log errors but don't add them to messages
-                console.error('[executeRound] Error event:', truncateLargeValues((event as any).error));
-                break;
+                yield functionOutputEvent;
             }
         }
+
+        for (const bufferedEvent of toolEventBuffer) {
+            yield { ...bufferedEvent, request_id: requestId };
+        }
+    };
+
+    let streamFailure: unknown;
+
+    try {
+        for await (let event of stream) {
+            event = { ...event, request_id: requestId };
+
+            if (event.type === 'message_complete' && structuredOutputSchema) {
+                const messageEvent = event as MessageEventBase;
+                if (hasTerminalTextContent(messageEvent.content, true)) {
+                    const validationResult = validateJsonResponseContent(messageEvent.content, structuredOutputSchema);
+                    if (validationResult.ok === false) {
+                        event = toTerminalErrorEvent({
+                            request_id: requestId,
+                            error: validationResult.error,
+                        }) as ProviderStreamEvent;
+                    }
+                }
+            }
+
+            if (event.type === 'tool_start') {
+                const toolEvent = event as ToolEvent;
+                if (toolEvent.tool_call) {
+                    const toolCall = toolEvent.tool_call;
+
+                    let argumentsFormatted: string | undefined;
+                    try {
+                        const tool = agent.tools?.find(t => t.definition.function.name === toolCall.function.name);
+
+                        if (tool && 'definition' in tool && tool.definition.function.parameters.properties) {
+                            const parsedArgs = JSON.parse(toolCall.function.arguments || '{}');
+                            if (typeof parsedArgs === 'object' && parsedArgs !== null && !Array.isArray(parsedArgs)) {
+                                const paramNames = Object.keys(tool.definition.function.parameters.properties);
+
+                                const orderedArgs: Record<string, any> = {};
+                                for (const param of paramNames) {
+                                    if (param in parsedArgs) {
+                                        orderedArgs[param] = parsedArgs[param];
+                                    }
+                                }
+
+                                argumentsFormatted = JSON.stringify(orderedArgs, null, 2);
+                            }
+                        }
+                    } catch (error) {
+                        console.debug('Failed to format tool arguments:', error);
+                    }
+
+                    if (argumentsFormatted) {
+                        toolCallFormattedArgs.set(toolCall.id, argumentsFormatted);
+                    }
+
+                    event = {
+                        ...event,
+                        tool_call: {
+                            ...toolCall,
+                            function: {
+                                ...toolCall.function,
+                                arguments_formatted: argumentsFormatted,
+                            },
+                        },
+                    };
+                }
+            }
+
+            if (event.type === 'message_complete') {
+                const messageEvent = event as MessageEventBase;
+                if (hasTerminalTextContent(messageEvent.content, Boolean(structuredOutputSchema))) {
+                    sawTerminalProviderEvent = true;
+                }
+            } else if (event.type === 'tool_start' || event.type === 'file_complete' || event.type === 'error') {
+                sawTerminalProviderEvent = true;
+            }
+
+            if (
+                event.type === 'error' &&
+                ((event as any).recoverable === false || sawToolCallThisRound)
+            ) {
+                sawTerminalProviderFailure = true;
+            }
+
+            yield event;
+            await emitEvent(event, agent, model);
+
+            switch (event.type) {
+                case 'cost_update': {
+                    const costEvent = event as any;
+                    if (costEvent.usage?.cost) {
+                        totalCost += costEvent.usage.cost;
+                    }
+                    break;
+                }
+
+                case 'message_complete': {
+                    const messageEvent = event as MessageEventBase;
+                    if (sawToolCallThisRound) {
+                        break;
+                    }
+
+                    if (
+                        messageEvent.thinking_content ||
+                        (!messageEvent.content && messageEvent.message_id)
+                    ) {
+                        const thinkingMessage = convertToThinkingMessage(messageEvent, model);
+
+                        if (agent.onThinking) {
+                            await agent.onThinking(thinkingMessage);
+                        }
+
+                        history.add(thinkingMessage);
+                        yield {
+                            type: 'response_output',
+                            message: thinkingMessage,
+                            request_id: requestId,
+                        };
+                    }
+                    if (hasTerminalTextContent(messageEvent.content, Boolean(structuredOutputSchema))) {
+                        const contentMessage = convertToOutputMessage(messageEvent, model, 'completed');
+
+                        if (agent.onResponse) {
+                            await agent.onResponse(contentMessage);
+                        }
+
+                        history.add(contentMessage);
+                        yield {
+                            type: 'response_output',
+                            message: contentMessage,
+                            request_id: requestId,
+                        };
+                    }
+                    break;
+                }
+
+                case 'tool_start': {
+                    const toolEvent = event as ToolEvent;
+                    if (!toolEvent.tool_call) {
+                        break;
+                    }
+                    sawToolCallThisRound = true;
+
+                    const remainingCalls = maxToolCalls - currentToolCalls;
+                    if (remainingCalls <= 0) {
+                        console.warn(`Tool call limit reached (${maxToolCalls}). Skipping tool calls.`);
+                        break;
+                    }
+
+                    const toolCall = toolEvent.tool_call;
+                    const functionCall = convertToFunctionCall(toolCall, model, 'completed');
+
+                    const trackedExecution: TrackedToolExecution = {
+                        toolCall,
+                        promise: processToolCall(toolCall, agent),
+                        settled: false,
+                    };
+                    trackedExecution.promise = trackedExecution.promise.then(
+                        result => {
+                    if (!trackedExecution.settled) {
+                        trackedExecution.settled = true;
+                        trackedExecution.result = result;
+                    }
+                    return trackedExecution.result ?? result;
+                },
+                error => {
+                    const result = createToolFailureResult(toolCall, error);
+                    if (!trackedExecution.settled) {
+                        trackedExecution.settled = true;
+                        trackedExecution.result = result;
+                    }
+                    return trackedExecution.result ?? result;
+                }
+            );
+            toolExecutions.push(trackedExecution);
+
+                    history.add(functionCall);
+                    yield {
+                        type: 'response_output',
+                        message: functionCall,
+                        request_id: requestId,
+                    };
+                    break;
+                }
+
+                case 'error': {
+                    console.error('[executeRound] Error event:', truncateLargeValues((event as any).error));
+                    break;
+                }
+            }
+        }
+    } catch (error) {
+        streamFailure = error;
+    }
+
+    if (!sawTerminalProviderEvent && streamFailure === undefined) {
+        const emptyResponseError = toTerminalErrorEvent({
+            request_id: requestId,
+            error: `Provider ${provider.provider_id} ended the stream without any terminal content, tool calls, files, or errors.`,
+        }) as ProviderStreamEvent;
+        yield emptyResponseError;
+        await emitEvent(emptyResponseError, agent, model);
     }
 
     // Calculate request duration
     const request_duration = Date.now() - startTime;
 
-    // Complete then process any tool calls
-    const toolResults: ToolCallResult[] = await Promise.all(toolPromises);
-    const terminalToolNames = getTerminalToolNames(agent);
+    const shouldUseBoundedFailureFinalization =
+        sawTerminalProviderFailure || (streamFailure !== undefined && isTerminalRoundError(streamFailure));
 
-    for (const toolResult of toolResults) {
-        const toolName = toolResult.toolCall.function.name;
-        const isTerminalTool = terminalToolNames.has(toolName);
+    yield* finalizeToolResults(shouldUseBoundedFailureFinalization ? 'bounded_failure' : 'wait_all');
 
-        // Get the formatted arguments if we stored them
-        const formattedArgs = toolCallFormattedArgs.get(toolResult.toolCall.id);
-
-        // Create tool call with formatted arguments
-        const toolCallWithFormattedArgs = formattedArgs
-            ? {
-                  ...toolResult.toolCall,
-                  function: {
-                      ...toolResult.toolCall.function,
-                      arguments_formatted: formattedArgs,
-                  },
-              }
-            : toolResult.toolCall;
-
-        const toolDoneEvent: ProviderStreamEvent = {
-            type: 'tool_done',
-            request_id: requestId,
-            tool_call: toolCallWithFormattedArgs,
-            result: {
-                call_id: toolResult.call_id || toolResult.id,
-                output: toolResult.output,
-                error: toolResult.error,
-            },
-        };
-        yield toolDoneEvent;
-        // Emit tool done event through global event controller
-        await emitEvent(toolDoneEvent, agent, model);
-
-        // For terminal tools, don't add output to history or send it back to the model.
-        if (!isTerminalTool) {
-            const functionOutput = convertToFunctionCallOutput(toolResult, model, 'completed');
-
-            history.add(functionOutput);
-            yield {
-                type: 'response_output',
-                message: functionOutput,
-                request_id: requestId,
-            };
-        }
+    if (streamFailure !== undefined) {
+        throw streamFailure;
     }
 
     // Calculate full duration
@@ -648,11 +934,6 @@ async function* executeRound(
 
     // Also emit through global event controller
     await emitEvent(agentDoneEvent, agent, model);
-
-    // Yield any events that were buffered during tool execution
-    for (const bufferedEvent of toolEventBuffer) {
-        yield { ...bufferedEvent, request_id: requestId };
-    }
 }
 
 /**
@@ -663,8 +944,10 @@ async function* performVerification(
     output: string,
     messages: ResponseInput,
     attempt: number = 0
-): AsyncGenerator<ProviderStreamEvent> {
-    if (!agent.verifier) return;
+): AsyncGenerator<ProviderStreamEvent, { passed: boolean; error?: string }, void> {
+    if (!agent.verifier) {
+        return { passed: true };
+    }
 
     const maxAttempts = agent.maxVerificationAttempts || 2;
 
@@ -677,7 +960,7 @@ async function* performVerification(
             type: 'message_delta',
             content: '\n\n✓ Output verified',
         } as ProviderStreamEvent;
-        return;
+        return { passed: true };
     }
 
     // Verification failed
@@ -723,14 +1006,25 @@ async function* performVerification(
 
         // Verify the retry
         if (retryOutput) {
-            yield* performVerification(agent, retryOutput, messages, attempt + 1);
+            return yield* performVerification(agent, retryOutput, messages, attempt + 1);
         }
+
+        return {
+            passed: false,
+            error: 'Verification retry did not produce a final response.',
+        };
     } else {
         // Max attempts reached
+        const failureMessage = `Verification failed after ${maxAttempts} attempts: ${verification.reason}`;
         yield {
             type: 'message_delta',
-            content: `\n\n❌ Verification failed after ${maxAttempts} attempts: ${verification.reason}`,
+            content: `\n\n❌ ${failureMessage}`,
         } as ProviderStreamEvent;
+
+        return {
+            passed: false,
+            error: failureMessage,
+        };
     }
 }
 
@@ -740,13 +1034,13 @@ async function* performVerification(
 async function processToolCall(toolCall: ToolCall, agent: AgentDefinition): Promise<ToolCallResult> {
     // Process all tool calls in parallel
 
-    // Apply tool handler lifecycle if available
-    if (agent.onToolCall) {
-        await agent.onToolCall(toolCall);
-    }
-
     // Execute tool
     try {
+        // Apply tool handler lifecycle if available
+        if (agent.onToolCall) {
+            await agent.onToolCall(toolCall);
+        }
+
         if (!agent.tools) {
             throw new Error('No tools available for agent');
         }
@@ -778,25 +1072,39 @@ async function processToolCall(toolCall: ToolCall, agent: AgentDefinition): Prom
 
         return toolCallResult;
     } catch (error) {
-        // Handle tool error
-        const errorOutput =
-            error instanceof Error
-                ? `Tool execution failed: ${error.message}`
-                : `Tool execution failed: ${String(error)}`;
-
-        const toolCallResult: ToolCallResult = {
-            toolCall,
-            id: toolCall.id,
-            call_id: toolCall.call_id || toolCall.id,
-            error: errorOutput,
-        };
+        const toolCallResult = createToolFailureResult(toolCall, error);
 
         if (agent.onToolError) {
-            await agent.onToolError(toolCallResult);
+            try {
+                await agent.onToolError(toolCallResult);
+            } catch (hookError) {
+                console.error('[processToolCall] onToolError hook failed:', hookError);
+            }
         }
 
         return toolCallResult;
     }
+}
+
+function createToolFailureResult(toolCall: ToolCall, error: unknown): ToolCallResult {
+    const errorOutput =
+        error instanceof Error
+            ? `Tool execution failed: ${error.message}`
+            : `Tool execution failed: ${String(error)}`;
+
+    return {
+        toolCall,
+        id: toolCall.id,
+        call_id: toolCall.call_id || toolCall.id,
+        error: errorOutput,
+    };
+}
+
+function createToolFinalizationFailureResult(toolCall: ToolCall): ToolCallResult {
+    return createToolFailureResult(
+        toolCall,
+        'Tool did not finish before request finalization after a provider failure.'
+    );
 }
 
 /**

--- a/docs/failure-detection.md
+++ b/docs/failure-detection.md
@@ -1,0 +1,226 @@
+# Failure Detection
+
+This document describes how failure detection works across `ensembleRequest`,
+`ensembleImage`, and `ensembleResult`, with a focus on JSON/text requests and
+image generation workflows.
+
+## Goal
+
+Callers should be able to detect terminal failures as soon as Ensemble knows a
+ request has failed, without relying on external heartbeat timers.
+
+Heartbeat monitors are still useful for process-level liveness, but they should
+not be the primary mechanism for deciding whether an Ensemble operation failed.
+
+## Shared Contract
+
+Ensemble now emits a shared lifecycle event:
+
+```ts
+{
+  type: 'operation_status',
+  operation: 'request' | 'image' | 'result',
+  status: 'started' | 'retrying' | 'failed' | 'completed',
+  error?: string,
+  reason?: string,
+  recoverable?: boolean,
+  terminal?: boolean,
+  will_continue?: boolean,
+  attempt?: number,
+  max_attempts?: number,
+  request_id?: string,
+}
+```
+
+Interpretation rules:
+
+- `status: 'retrying'` means Ensemble has observed a failure, but the overall
+  operation is still alive and will continue.
+- `status: 'failed'` with `terminal: true` means the operation is definitively
+  failed and the caller can retry or move on immediately.
+- `status: 'completed'` means the overall operation succeeded.
+
+The legacy `error` event is still emitted for compatibility, but callers that
+need reliable orchestration should treat `operation_status` as authoritative.
+
+## Request Flow
+
+`ensembleRequest(...)` emits:
+
+- `operation_status: started` at the beginning of the overall request.
+- `operation_status: retrying` when a round fails and Ensemble will retry.
+- `operation_status: failed` when retries are exhausted or an unrecoverable
+  exception escapes.
+- `operation_status: completed` before `stream_end` when the request finishes
+  successfully.
+
+This means a caller can stop waiting as soon as it sees:
+
+```ts
+event.type === 'operation_status' &&
+event.operation === 'request' &&
+event.status === 'failed' &&
+event.terminal === true
+```
+
+## Image Flow
+
+`ensembleImage(..., { stream: true })` emits:
+
+- `image_start`
+- `operation_status: started`
+- zero or more `cost_update`
+- one or more `file_complete`
+- `image_complete`
+- `operation_status: completed`
+
+Or, on failure:
+
+- `image_start`
+- `operation_status: started`
+- `operation_status: failed`
+- `error`
+
+This is important because image providers usually do not stream provider-native
+queue/progress/failure states back through Ensemble. Instead, each provider runs
+its own request or polling loop, throws on terminal failure, and the top-level
+image wrapper converts that into a unified terminal failure event.
+
+## ensembleResult
+
+`ensembleResult(stream, { failFast: true })` now returns as soon as it sees a
+terminal failure event instead of waiting for `stream_end`.
+
+It also records structured failure metadata:
+
+```ts
+{
+  error?: string,
+  failure?: {
+    operation?: 'request' | 'image' | 'result',
+    request_id?: string,
+    reason?: string,
+    terminal: boolean,
+    recoverable: boolean,
+    detectedAt: Date,
+  }
+}
+```
+
+Use this when you want a Promise-based API but still need immediate failure
+detection.
+
+## Recommended Caller Pattern
+
+### Stream-first orchestration
+
+```ts
+for await (const event of ensembleImage(prompt, agent, { stream: true, timeout_ms: 120000 })) {
+  if (event.type === 'operation_status') {
+    if (event.status === 'retrying') {
+      // optional logging or metrics
+    }
+
+    if (event.status === 'failed' && event.terminal) {
+      // retry now, switch to fallback, or continue workflow without this result
+      break;
+    }
+  }
+}
+```
+
+### Promise-style aggregation with fail-fast behavior
+
+```ts
+const result = await ensembleResult(stream, { failFast: true });
+
+if (result.failure?.terminal) {
+  // immediate retry / fallback path
+}
+```
+
+## Gemini, OpenAI, and Grok Image Generation
+
+### Summary
+
+For these three providers, the shared failure handling works because each
+provider already throws on terminal image-generation failure. `ensembleImage`
+then converts that thrown error into a unified `operation_status: failed` event.
+
+### OpenAI
+
+Implementation: `model_providers/openai.ts#createImage`
+
+Observed failure behavior:
+
+- Throws if `ImageGenerationOpts.n` is invalid.
+- Throws if fetching a source image URL for image editing fails.
+- Throws if the OpenAI Images API returns a response without a `data` array.
+- Throws if any returned item is missing `b64_json`.
+- Throws if no images are returned.
+
+Operational result:
+
+- Provider-detected failures become immediate terminal failures in
+  `ensembleImage(..., { stream: true })`.
+- Stalled SDK calls can be bounded with `timeout_ms` at the Ensemble wrapper
+  layer.
+
+### Gemini
+
+Implementation: `model_providers/gemini.ts#createImage`
+
+Observed failure behavior:
+
+- Throws if `ImageGenerationOpts.n` is invalid.
+- Throws when Gemini image streaming finishes without any image parts.
+- Throws when Imagen responses contain no generated images.
+- Logs and rethrows provider exceptions.
+
+Operational result:
+
+- Empty or malformed Gemini image outputs become terminal failures.
+- Stalled provider calls can be bounded with `timeout_ms` at the wrapper layer.
+
+### Grok / xAI
+
+Implementation: `model_providers/grok.ts#createImage`
+
+Observed failure behavior:
+
+- Throws if `ImageGenerationOpts.n` is outside `1..10`.
+- Throws if masks are supplied, since masks are not supported here yet.
+- Throws if too many source images are supplied.
+- Throws if source images are malformed.
+- Throws if the xAI API response contains no image outputs.
+
+Operational result:
+
+- Invalid request-shape and empty-response failures become immediate terminal
+  failures in `ensembleImage`.
+- Stalled provider calls can be bounded with `timeout_ms` at the wrapper layer.
+
+## What This Solves
+
+This removes the need to infer request failure from heartbeat expiration in the
+common cases:
+
+- provider returns a terminal error
+- provider returns malformed or empty image output
+- Ensemble retries have been exhausted
+- the caller sets `timeout_ms` and the provider stalls
+
+## What This Does Not Solve
+
+This does not create provider-native progress events for image jobs. Providers
+such as Gemini, OpenAI, and Grok still expose image generation as a Promise-like
+operation in Ensemble, so the shared wrapper can report:
+
+- started
+- terminal failure
+- terminal success
+
+but not granular in-flight states like queued, running, or polling step N.
+
+If provider-native progress becomes important later, the next step would be a
+provider-agnostic async job interface rather than Promise-only `createImage(...)`.

--- a/model_providers/claude.ts
+++ b/model_providers/claude.ts
@@ -204,6 +204,44 @@ function cleanBase64Data(imageData: string): string {
     return imageData.replace(/^data:image\/[a-z]+;base64,/, '');
 }
 
+function finalizeClaudeToolArguments(currentToolCall: any): string | undefined {
+    const partialArgs = currentToolCall?.function?._partialArguments;
+    if (!partialArgs) {
+        return undefined;
+    }
+
+    try {
+        JSON.parse(partialArgs);
+        currentToolCall.function.arguments = partialArgs;
+        delete currentToolCall.function._partialArguments;
+        return undefined;
+    } catch (jsonError) {
+        console.warn(
+            `Invalid JSON in partial arguments for ${currentToolCall.function.name}: ${partialArgs}`,
+            jsonError
+        );
+
+        if (partialArgs.includes('}{')) {
+            const firstBraceIndex = partialArgs.indexOf('{');
+            const firstCloseBraceIndex = partialArgs.indexOf('}') + 1;
+            if (firstBraceIndex !== -1 && firstCloseBraceIndex > firstBraceIndex) {
+                const firstJsonStr = partialArgs.substring(firstBraceIndex, firstCloseBraceIndex);
+                try {
+                    JSON.parse(firstJsonStr);
+                    currentToolCall.function.arguments = firstJsonStr;
+                    delete currentToolCall.function._partialArguments;
+                    return undefined;
+                } catch (extractError) {
+                    console.error(`Failed to extract valid JSON: ${firstJsonStr}`, extractError);
+                }
+            }
+        }
+
+        delete currentToolCall.function._partialArguments;
+        return `Claude emitted malformed tool arguments for ${currentToolCall.function.name}.`;
+    }
+}
+
 /**
  * Processes images and adds them to the input array for Claude
  * Resizes images to max 1024px width and splits into sections if height > 768px
@@ -895,47 +933,17 @@ export class ClaudeProvider extends BaseModelProvider {
                     ) {
                         try {
                             // Finalize arguments if they were streamed partially
-                            if (currentToolCall.function._partialArguments) {
-                                // Validate that we have proper JSON before finalizing
-                                const partialArgs = currentToolCall.function._partialArguments;
-                                try {
-                                    JSON.parse(partialArgs); // Validate JSON
-                                    currentToolCall.function.arguments = partialArgs;
-                                } catch (jsonError) {
-                                    console.warn(
-                                        `Invalid JSON in partial arguments for ${currentToolCall.function.name}: ${partialArgs}`,
-                                        jsonError
-                                    );
-                                    // Try to extract the first valid JSON object if it's concatenated
-                                    if (partialArgs.includes('}{')) {
-                                        const firstBraceIndex = partialArgs.indexOf('{');
-                                        const firstCloseBraceIndex = partialArgs.indexOf('}') + 1;
-                                        if (firstBraceIndex !== -1 && firstCloseBraceIndex > firstBraceIndex) {
-                                            const firstJsonStr = partialArgs.substring(
-                                                firstBraceIndex,
-                                                firstCloseBraceIndex
-                                            );
-                                            try {
-                                                JSON.parse(firstJsonStr); // Validate extracted JSON
-                                                currentToolCall.function.arguments = firstJsonStr;
-                                                console.log(
-                                                    `Extracted valid JSON from partial arguments: ${firstJsonStr}`
-                                                );
-                                            } catch (extractError) {
-                                                console.error(
-                                                    `Failed to extract valid JSON: ${firstJsonStr}`,
-                                                    extractError
-                                                );
-                                                currentToolCall.function.arguments = '{}';
-                                            }
-                                        } else {
-                                            currentToolCall.function.arguments = '{}';
-                                        }
-                                    } else {
-                                        currentToolCall.function.arguments = '{}';
-                                    }
-                                }
-                                delete currentToolCall.function._partialArguments; // Clean up temporary field
+                            const malformedArgumentsError = finalizeClaudeToolArguments(currentToolCall);
+                            if (malformedArgumentsError) {
+                                log_llm_error(requestId, malformedArgumentsError);
+                                yield {
+                                    type: 'error',
+                                    error: malformedArgumentsError,
+                                    recoverable: false,
+                                };
+                                toolCallStarted = false;
+                                currentToolCall = null;
+                                continue;
                             }
                             yield {
                                 type: 'tool_start',
@@ -975,44 +983,17 @@ export class ClaudeProvider extends BaseModelProvider {
                             // Only emit tool_start if we haven't already emitted it
                             // This is a fallback in case content_block_stop didn't fire
                             // Finalize arguments if they were streamed partially with proper JSON validation
-                            if (currentToolCall.function._partialArguments) {
-                                const partialArgs = currentToolCall.function._partialArguments;
-                                try {
-                                    JSON.parse(partialArgs); // Validate JSON
-                                    currentToolCall.function.arguments = partialArgs;
-                                } catch (jsonError) {
-                                    console.warn(
-                                        `Invalid JSON in partial arguments at message_stop for ${currentToolCall.function.name}: ${partialArgs}`,
-                                        jsonError
-                                    );
-                                    // Try to extract the first valid JSON object if it's concatenated
-                                    if (partialArgs.includes('}{')) {
-                                        const firstBraceIndex = partialArgs.indexOf('{');
-                                        const firstCloseBraceIndex = partialArgs.indexOf('}') + 1;
-                                        if (firstBraceIndex !== -1 && firstCloseBraceIndex > firstBraceIndex) {
-                                            const firstJsonStr = partialArgs.substring(
-                                                firstBraceIndex,
-                                                firstCloseBraceIndex
-                                            );
-                                            try {
-                                                JSON.parse(firstJsonStr); // Validate extracted JSON
-                                                currentToolCall.function.arguments = firstJsonStr;
-                                                console.log(`Extracted valid JSON at message_stop: ${firstJsonStr}`);
-                                            } catch (extractError) {
-                                                console.error(
-                                                    `Failed to extract valid JSON at message_stop: ${firstJsonStr}`,
-                                                    extractError
-                                                );
-                                                currentToolCall.function.arguments = '{}';
-                                            }
-                                        } else {
-                                            currentToolCall.function.arguments = '{}';
-                                        }
-                                    } else {
-                                        currentToolCall.function.arguments = '{}';
-                                    }
-                                }
-                                delete currentToolCall.function._partialArguments;
+                            const malformedArgumentsError = finalizeClaudeToolArguments(currentToolCall);
+                            if (malformedArgumentsError) {
+                                log_llm_error(requestId, malformedArgumentsError);
+                                yield {
+                                    type: 'error',
+                                    error: malformedArgumentsError,
+                                    recoverable: false,
+                                };
+                                currentToolCall = null;
+                                toolCallStarted = false;
+                                continue;
                             }
 
                             yield {

--- a/model_providers/openai.ts
+++ b/model_providers/openai.ts
@@ -63,24 +63,54 @@ function requiresReasoning(modelName: string): boolean {
  * This includes adding required fields, setting additionalProperties: false,
  * and removing unsupported keywords
  */
-function processSchemaForOpenAI(schema: any, originalProperties?: any): any {
+function deriveRequiredProperties(
+    sourceSchema: any,
+    propertyNames: string[],
+    mode: 'tool_parameters' | 'json_schema'
+) {
+    if (!sourceSchema?.properties || typeof sourceSchema.properties !== 'object') {
+        return undefined;
+    }
+
+    if (mode === 'tool_parameters') {
+        if (Array.isArray(sourceSchema.required)) {
+            const explicitlyRequired = new Set(sourceSchema.required);
+            return propertyNames.filter(name => explicitlyRequired.has(name));
+        }
+
+        return propertyNames.filter(name => sourceSchema.properties?.[name]?.optional !== true);
+    }
+
+    return propertyNames;
+}
+
+function processSchemaForOpenAI(
+    schema: any,
+    originalProperties?: any,
+    mode: 'tool_parameters' | 'json_schema' = 'tool_parameters'
+): any {
     // Clone schema to avoid modifying the original
     const processedSchema = JSON.parse(JSON.stringify(schema));
 
     // Recursively process the schema for OpenAI compatibility
-    const processSchemaRecursively = (schema: any) => {
-        if (!schema || typeof schema !== 'object') return;
+    const processSchemaRecursively = (currentSchema: any, sourceSchema?: any) => {
+        if (!currentSchema || typeof currentSchema !== 'object') return;
 
         // 1. Remove 'optional: true' flag
-        if (schema.optional === true) {
-            delete schema.optional;
+        if (currentSchema.optional === true) {
+            delete currentSchema.optional;
         }
 
         // 2. Convert 'oneOf' to 'anyOf'
-        if (Array.isArray(schema.oneOf)) {
-            schema.anyOf = schema.oneOf;
-            delete schema.oneOf;
+        if (Array.isArray(currentSchema.oneOf)) {
+            currentSchema.anyOf = currentSchema.oneOf;
+            delete currentSchema.oneOf;
         }
+
+        const variantSourceSchemas = {
+            anyOf: sourceSchema?.anyOf ?? sourceSchema?.oneOf,
+            allOf: sourceSchema?.allOf,
+        };
 
         // 3. Remove OpenAI-incompatible validation keywords
         const unsupportedKeywords = [
@@ -106,35 +136,41 @@ function processSchemaForOpenAI(schema: any, originalProperties?: any): any {
             'default', // Remove default values as OpenAI doesn't support them
         ];
         unsupportedKeywords.forEach(keyword => {
-            if (schema[keyword] !== undefined) {
-                delete schema[keyword];
+            if (currentSchema[keyword] !== undefined) {
+                delete currentSchema[keyword];
             }
         });
 
         // Detect if it's an object-like schema
-        const isObject = schema.type === 'object' || (schema.type === undefined && schema.properties !== undefined);
+        const isObject =
+            currentSchema.type === 'object' ||
+            (currentSchema.type === undefined && currentSchema.properties !== undefined);
 
         // 4. Recurse into nested structures first
         // Process variants (anyOf, allOf)
         for (const key of ['anyOf', 'allOf'] as const) {
-            if (Array.isArray(schema[key])) {
-                schema[key].forEach((variantSchema: any) => processSchemaRecursively(variantSchema));
+            if (Array.isArray(currentSchema[key])) {
+                currentSchema[key].forEach((variantSchema: any, index: number) =>
+                    processSchemaRecursively(variantSchema, variantSourceSchemas[key]?.[index])
+                );
             }
         }
         // Process properties
-        if (isObject && schema.properties) {
-            for (const propName in schema.properties) {
-                processSchemaRecursively(schema.properties[propName]);
+        if (isObject && currentSchema.properties) {
+            for (const propName in currentSchema.properties) {
+                processSchemaRecursively(currentSchema.properties[propName], sourceSchema?.properties?.[propName]);
             }
         }
         // Process array items
-        if (schema.type === 'array' && schema.items !== undefined) {
-            if (Array.isArray(schema.items)) {
+        if (currentSchema.type === 'array' && currentSchema.items !== undefined) {
+            if (Array.isArray(currentSchema.items)) {
                 // Tuple validation
-                schema.items.forEach((itemSchema: any) => processSchemaRecursively(itemSchema));
-            } else if (typeof schema.items === 'object') {
+                currentSchema.items.forEach((itemSchema: any, index: number) =>
+                    processSchemaRecursively(itemSchema, sourceSchema?.items?.[index])
+                );
+            } else if (typeof currentSchema.items === 'object') {
                 // Single schema for all items
-                processSchemaRecursively(schema.items);
+                processSchemaRecursively(currentSchema.items, sourceSchema?.items);
             }
         }
 
@@ -142,45 +178,42 @@ function processSchemaForOpenAI(schema: any, originalProperties?: any): any {
         if (isObject) {
             // Always set additionalProperties: false for objects (required by OpenAI in strict mode)
             // This is necessary even for objects without properties
-            schema.additionalProperties = false;
+            currentSchema.additionalProperties = false;
 
             // Set 'required' array to include all current properties (required by OpenAI for strict mode)
-            if (schema.properties) {
-                const currentRequired = Object.keys(schema.properties);
+            if (currentSchema.properties) {
+                const currentRequired = deriveRequiredProperties(
+                    sourceSchema,
+                    Object.keys(currentSchema.properties),
+                    mode
+                );
                 // Only add required array if there are properties to require
-                if (currentRequired.length > 0) {
-                    schema.required = currentRequired;
+                if (currentRequired && currentRequired.length > 0) {
+                    currentSchema.required = currentRequired;
                 } else {
                     // If properties is an empty object {}, remove required
-                    delete schema.required;
+                    delete currentSchema.required;
                 }
             } else {
                 // If no properties field, remove required
-                delete schema.required;
+                delete currentSchema.required;
             }
         }
     };
 
     // Apply the recursive processing to the cloned schema
-    processSchemaRecursively(processedSchema);
+    processSchemaRecursively(processedSchema, schema);
 
-    // If original properties were provided (for tools), fix the top-level 'required' array
-    if (originalProperties) {
-        // AFTER recursion, fix the top-level 'required' array based on the ORIGINAL properties.
-        // This ensures top-level optional parameters are correctly handled, overriding the
-        // potentially stricter 'required' array set during recursion for the top-level object.
-        const topLevelRequired: string[] = [];
-        for (const propName in originalProperties) {
-            // Check the *original* property definition for the optional flag
-            if (!originalProperties[propName].optional) {
-                topLevelRequired.push(propName);
-            }
-        }
-        // Set the correct top-level required array on the processed schema
-        if (topLevelRequired.length > 0) {
+    // For tools, preserve caller-specified required subsets and optional flags at the top level.
+    if (mode === 'tool_parameters' && originalProperties && !Array.isArray(schema?.required)) {
+        const topLevelRequired = deriveRequiredProperties(
+            { properties: originalProperties, required: schema?.required },
+            Object.keys(originalProperties),
+            mode
+        );
+        if (topLevelRequired && topLevelRequired.length > 0) {
             processedSchema.required = topLevelRequired;
         } else {
-            // Ensure the top-level object has no required array if no properties were originally required
             delete processedSchema.required;
         }
     }
@@ -524,7 +557,10 @@ export class OpenAIProvider extends BaseModelProvider {
         try {
             // Extract options with defaults, mapping to the original function parameters
             model = model || 'gpt-image-1.5';
-            const number_of_images = opts?.n || 1;
+            const number_of_images = opts?.n ?? 1;
+            if (!Number.isInteger(number_of_images) || number_of_images < 1) {
+                throw new Error('[OpenAI] ImageGenerationOpts.n must be a positive integer.');
+            }
 
             // Map quality options
             let quality: 'low' | 'medium' | 'high' | 'auto' = 'auto';
@@ -599,6 +635,11 @@ export class OpenAIProvider extends BaseModelProvider {
                     if (imageData.startsWith('http://') || imageData.startsWith('https://')) {
                         // Handle URL case - fetch the image
                         const imageResponse = await fetch(imageData);
+                        if (!imageResponse.ok) {
+                            throw new Error(
+                                `[OpenAI] Failed to fetch source image: ${imageResponse.status} ${imageResponse.statusText}`
+                            );
+                        }
                         const imageBuffer = await imageResponse.arrayBuffer();
                         const ct = imageResponse.headers.get('content-type') || 'image/png';
 
@@ -731,6 +772,10 @@ export class OpenAIProvider extends BaseModelProvider {
             }
 
             // Extract the base64 image data for all images
+            if (!Array.isArray(response.data)) {
+                throw new Error('OpenAI image response did not include a data array');
+            }
+
             const imageDataUrls = response.data.map(item => {
                 const imageData = item?.b64_json;
                 if (!imageData) {
@@ -1349,7 +1394,7 @@ export class OpenAIProvider extends BaseModelProvider {
                 requestParams.text = {
                     format: {
                         ...wrapperWithoutSchema, // name, type:'json_schema', etc.
-                        schema: processSchemaForOpenAI(schema),
+                        schema: processSchemaForOpenAI(schema, undefined, 'json_schema'),
                     },
                 };
             }
@@ -1729,16 +1774,19 @@ export class OpenAIProvider extends BaseModelProvider {
                 // Clean up: Check if any tool calls were started but not completed
                 if (toolCallStates.size > 0) {
                     console.warn(`Stream ended with ${toolCallStates.size} incomplete tool call(s).`);
-                    for (const [, toolCall] of toolCallStates.entries()) {
-                        // Optionally yield incomplete tool calls if appropriate for your application
-                        if (toolCall.function.name) {
-                            // Check if it was minimally valid
-                            yield {
-                                type: 'tool_start', // Or maybe 'tool_incomplete'?
-                                tool_call: toolCall as ToolCall,
-                            };
-                        }
-                    }
+                    const incompleteToolNames = Array.from(toolCallStates.values())
+                        .map(toolCall => toolCall.function.name)
+                        .filter((name): name is string => typeof name === 'string' && name.length > 0);
+                    const errorMessage =
+                        incompleteToolNames.length > 0
+                            ? `OpenAI response ended with incomplete tool call arguments for: ${incompleteToolNames.join(', ')}`
+                            : 'OpenAI response ended with incomplete tool call arguments.';
+                    log_llm_error(requestId, errorMessage);
+                    yield {
+                        type: 'error',
+                        error: errorMessage,
+                        recoverable: false,
+                    };
                     toolCallStates.clear(); // Clear the map
                 }
                 // Flush any buffered d

--- a/model_providers/openai_chat.ts
+++ b/model_providers/openai_chat.ts
@@ -678,7 +678,9 @@ export class OpenAIChat extends BaseModelProvider {
             if (settings?.json_schema) {
                 requestParams.response_format = {
                     type: 'json_schema',
-                    json_schema: settings.json_schema,
+                    json_schema: {
+                        ...settings.json_schema,
+                    },
                 };
             }
             // Check model features to determine tool support
@@ -1080,8 +1082,11 @@ export class OpenAIChat extends BaseModelProvider {
                     const completedToolCalls: ToolCall[] = Array.from(partialToolCallsByIndex.values()).filter(
                         call => call.id && call.function.name
                     );
+                    const validatedToolCalls: ToolCall[] = [];
+                    const malformedToolCallNames: string[] = [];
                     if (completedToolCalls.length > 0) {
                         for (const completedToolCall of completedToolCalls) {
+                            let toolCallMalformed = false;
                             // Validate and fix JSON arguments before yielding
                             if (completedToolCall.function.arguments) {
                                 try {
@@ -1104,22 +1109,41 @@ export class OpenAIChat extends BaseModelProvider {
                                             const parsed = JSON.parse(matches[0]);
                                             completedToolCall.function.arguments = JSON.stringify(parsed);
                                         } catch {
-                                            // If all else fails, use empty object
-                                            completedToolCall.function.arguments = '{}';
-                                            console.error(
-                                                `(${this.provider}) Could not parse arguments, using empty object`
-                                            );
+                                            toolCallMalformed = true;
+                                            console.error(`(${this.provider}) Could not parse tool arguments.`);
                                         }
                                     } else {
-                                        completedToolCall.function.arguments = '{}';
+                                        toolCallMalformed = true;
                                     }
                                 }
                             }
 
+                            if (toolCallMalformed) {
+                                malformedToolCallNames.push(completedToolCall.function.name);
+                                continue;
+                            }
+
+                            validatedToolCalls.push(completedToolCall);
+                        }
+
+                        if (malformedToolCallNames.length > 0) {
+                            const malformedToolCallError =
+                                malformedToolCallNames.length === 1
+                                    ? `Error (${this.provider}): Model emitted malformed tool arguments for ${malformedToolCallNames[0]}.`
+                                    : `Error (${this.provider}): Model emitted malformed tool arguments for ${malformedToolCallNames.join(', ')}.`;
+                            log_llm_error(requestId, malformedToolCallError);
                             yield {
-                                type: 'tool_start',
-                                tool_call: completedToolCall,
+                                type: 'error',
+                                error: malformedToolCallError,
+                                recoverable: false,
                             };
+                        } else {
+                            for (const completedToolCall of validatedToolCalls) {
+                                yield {
+                                    type: 'tool_start',
+                                    tool_call: completedToolCall,
+                                };
+                            }
                         }
                     } else {
                         log_llm_error(
@@ -1132,6 +1156,7 @@ export class OpenAIChat extends BaseModelProvider {
                         yield {
                             type: 'error',
                             error: `Error (${this.provider}): Model indicated tool calls, but none were parsed correctly.`,
+                            recoverable: false,
                         };
                     }
                 } else if (finishReason === 'length') {
@@ -1146,6 +1171,7 @@ export class OpenAIChat extends BaseModelProvider {
                     yield {
                         type: 'error',
                         error: `Error (${this.provider}): Response truncated (max_tokens). Partial: ${cleanedPartialContent.substring(0, 100)}...`,
+                        recoverable: false,
                     };
                 } else if (finishReason) {
                     const cleanedReasonContent = aggregatedContent.replaceAll(
@@ -1159,6 +1185,7 @@ export class OpenAIChat extends BaseModelProvider {
                     yield {
                         type: 'error',
                         error: `Error (${this.provider}): Response stopped due to: ${finishReason}. Content: ${cleanedReasonContent.substring(0, 100)}...`,
+                        recoverable: false,
                     };
                 } else {
                     // Handle stream ending without a finish reason

--- a/test/failure_detection.test.ts
+++ b/test/failure_detection.test.ts
@@ -1,0 +1,1735 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensembleRequest } from '../core/ensemble_request.js';
+import { ensembleImage } from '../core/ensemble_image.js';
+import { ensembleResult } from '../utils/ensemble_result.js';
+import { raceWithAbortAndTimeout, toTerminalErrorEvent } from '../utils/failure_detection.js';
+import type { AgentDefinition, ProviderStreamEvent } from '../types/types.js';
+
+vi.mock('../model_providers/model_provider.js', () => ({
+    getModelFromAgent: vi.fn().mockResolvedValue('test-model'),
+    getModelProvider: vi.fn(),
+}));
+
+describe('failure detection', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+    });
+
+    it('emits retrying and terminal request failure status events', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        let attempts = 0;
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'test-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                attempts += 1;
+                yield { type: 'error', error: `provider failure ${attempts}` } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = { model: 'test-model' };
+        const events: ProviderStreamEvent[] = [];
+
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const statusEvents = events.filter(event => event.type === 'operation_status') as Array<any>;
+        expect(statusEvents).toHaveLength(6);
+        expect(statusEvents[0]?.status).toBe('started');
+        expect(statusEvents.slice(1, 5).every(event => event.status === 'retrying')).toBe(true);
+        expect(statusEvents.slice(1, 5).every(event => event.recoverable === true)).toBe(true);
+        expect(statusEvents.slice(1, 5).every(event => event.terminal === false)).toBe(true);
+        expect(new Set(statusEvents.map(event => event.request_id)).size).toBe(1);
+
+        const finalStatus = statusEvents.at(-1);
+        expect(finalStatus?.status).toBe('failed');
+        expect(finalStatus?.recoverable).toBe(false);
+        expect(finalStatus?.terminal).toBe(true);
+        expect(finalStatus?.attempt).toBe(5);
+        expect(finalStatus?.error).toBe('provider failure 5');
+    });
+
+    it('keeps request lifecycle request_id stable when a retry later succeeds', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        let attempts = 0;
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'retry-success-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                attempts += 1;
+                if (attempts === 1) {
+                    yield { type: 'error', error: 'temporary provider failure' } as ProviderStreamEvent;
+                    return;
+                }
+
+                yield {
+                    type: 'message_complete',
+                    message_id: 'msg_success',
+                    content: 'Recovered response',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], { model: 'test-model' })) {
+            events.push(event);
+        }
+
+        const agentStarts = events.filter(event => event.type === 'agent_start') as Array<any>;
+        const statusEvents = events.filter(event => event.type === 'operation_status') as Array<any>;
+
+        expect(agentStarts).toHaveLength(2);
+        expect(agentStarts[0]?.request_id).not.toBe(agentStarts[1]?.request_id);
+        expect(statusEvents.map(event => event.status)).toEqual(['started', 'retrying', 'completed']);
+        expect(statusEvents.every(event => event.request_id === agentStarts[0]?.request_id)).toBe(true);
+    });
+
+    it('keeps request lifecycle request_id stable when onRequest fails before the provider stream starts', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        let attempts = 0;
+        let onRequestCalls = 0;
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'onrequest-retry-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                attempts += 1;
+                yield {
+                    type: 'message_complete',
+                    message_id: `msg_${attempts}`,
+                    content: 'Recovered response',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const recoverableHookError = Object.assign(new Error('temporary onRequest failure'), { recoverable: true });
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            onRequest: async (currentAgent, messages) => {
+                onRequestCalls += 1;
+                if (onRequestCalls === 1) {
+                    throw recoverableHookError;
+                }
+
+                return [currentAgent, messages];
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const agentStarts = events.filter(event => event.type === 'agent_start') as Array<any>;
+        const statusEvents = events.filter(event => event.type === 'operation_status') as Array<any>;
+
+        expect(agentStarts).toHaveLength(2);
+        expect(agentStarts[0]?.request_id).not.toBe(agentStarts[1]?.request_id);
+        expect(statusEvents.map(event => event.status)).toEqual(['started', 'retrying', 'completed']);
+        expect(statusEvents.every(event => event.request_id === agentStarts[0]?.request_id)).toBe(true);
+    });
+
+    it('emits a terminal image failure status before the error event', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'test-image-provider',
+            createImage: vi.fn().mockRejectedValue(new Error('image provider failed')),
+        } as any);
+
+        const agent: AgentDefinition = { model: 'test-model' };
+        const stream = ensembleImage('Draw a fox', agent, { stream: true }) as AsyncGenerator<ProviderStreamEvent>;
+        const events: ProviderStreamEvent[] = [];
+
+        for await (const event of stream) {
+            events.push(event);
+        }
+
+        expect(events[0]?.type).toBe('image_start');
+        expect(events[1]?.type).toBe('operation_status');
+        expect((events[1] as any).status).toBe('started');
+        expect((events[2] as any).type).toBe('operation_status');
+        expect((events[2] as any).status).toBe('failed');
+        expect((events[2] as any).terminal).toBe(true);
+        expect((events[2] as any).recoverable).toBe(false);
+        expect((events[3] as any).type).toBe('error');
+        expect((events[3] as any).error).toBe('image provider failed');
+    });
+
+    it('returns early from ensembleResult when failFast sees a terminal failure', async () => {
+        let returnCalled = false;
+        let nextCalls = 0;
+
+        const stream = {
+            async next() {
+                nextCalls += 1;
+                if (nextCalls === 1) {
+                    return {
+                        done: false,
+                        value: {
+                            type: 'operation_status',
+                            operation: 'image',
+                            status: 'failed',
+                            error: 'image failed',
+                            recoverable: false,
+                            terminal: true,
+                        },
+                    };
+                }
+
+                return new Promise(() => undefined);
+            },
+            async return() {
+                returnCalled = true;
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream, { failFast: true });
+
+        expect(returnCalled).toBe(true);
+        expect(result.completed).toBe(false);
+        expect(result.error).toBe('image failed');
+        expect(result.failure?.operation).toBe('image');
+        expect(result.failure?.terminal).toBe(true);
+        expect(result.failure?.recoverable).toBe(false);
+    });
+
+    it('preserves buffered outputs when ensembleResult fails fast', async () => {
+        let returnCalled = false;
+        const events: ProviderStreamEvent[] = [
+            {
+                type: 'response_output',
+                message: {
+                    type: 'message',
+                    role: 'assistant',
+                    content: 'partial answer',
+                    status: 'completed',
+                } as any,
+            } as ProviderStreamEvent,
+            {
+                type: 'file_complete',
+                data: 'https://example.com/file.png',
+                data_format: 'url',
+            } as ProviderStreamEvent,
+            {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-1',
+                    call_id: 'call-1',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent,
+            {
+                type: 'tool_done',
+                tool_call: {
+                    id: 'tool-1',
+                    call_id: 'call-1',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+                result: {
+                    call_id: 'call-1',
+                    output: 'sunny',
+                },
+            } as ProviderStreamEvent,
+            {
+                type: 'operation_status',
+                operation: 'request',
+                status: 'failed',
+                error: 'terminal failure',
+                recoverable: false,
+                terminal: true,
+            } as ProviderStreamEvent,
+        ];
+
+        const stream = {
+            async next() {
+                const value = events.shift();
+                return value ? { done: false, value } : new Promise(() => undefined);
+            },
+            async return() {
+                returnCalled = true;
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream, { failFast: true });
+
+        expect(returnCalled).toBe(true);
+        expect(result.completed).toBe(false);
+        expect(result.responseOutputs).toHaveLength(1);
+        expect(result.responseOutputs?.[0]).toMatchObject({ content: 'partial answer' });
+        expect(result.files).toEqual([
+            {
+                data: 'https://example.com/file.png',
+                data_format: 'url',
+                mime_type: undefined,
+            },
+        ]);
+        expect(result.tools?.totalCalls).toBe(1);
+        expect(result.tools?.calls[0]).toMatchObject({
+            call_id: 'call-1',
+            output: 'sunny',
+        });
+    });
+
+    it('waits for a following failed status before finishing failFast on a terminal error', async () => {
+        let returnCalled = false;
+        const events: ProviderStreamEvent[] = [
+            {
+                type: 'error',
+                request_id: 'req_failfast',
+                error: 'request failed',
+                recoverable: false,
+            } as ProviderStreamEvent,
+            {
+                type: 'operation_status',
+                operation: 'request',
+                status: 'failed',
+                request_id: 'req_failfast',
+                reason: 'terminal_error',
+                error: 'request failed',
+                recoverable: false,
+                terminal: true,
+            } as ProviderStreamEvent,
+        ];
+
+        const stream = {
+            async next() {
+                const value = events.shift();
+                return value ? { done: false, value } : new Promise(() => undefined);
+            },
+            async return() {
+                returnCalled = true;
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream, { failFast: true });
+
+        expect(returnCalled).toBe(true);
+        expect(result.completed).toBe(false);
+        expect(result.error).toBe('request failed');
+        expect(result.failure).toMatchObject({
+            operation: 'request',
+            request_id: 'req_failfast',
+            reason: 'terminal_error',
+            terminal: true,
+            recoverable: false,
+        });
+    });
+
+    it('returns immediately from failFast on a terminal error when no failed status follows', async () => {
+        let returnCalled = false;
+        let nextCalls = 0;
+
+        const stream = {
+            async next() {
+                nextCalls += 1;
+                if (nextCalls === 1) {
+                    return {
+                        done: false,
+                        value: {
+                            type: 'error',
+                            request_id: 'req_terminal_error_only',
+                            error: 'request failed without failed status',
+                            recoverable: false,
+                        },
+                    };
+                }
+
+                return new Promise(() => undefined);
+            },
+            async return() {
+                returnCalled = true;
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await Promise.race([
+            ensembleResult(stream, { failFast: true }),
+            new Promise<never>((_, reject) => {
+                setTimeout(() => reject(new Error('ensembleResult hung on terminal error without failed status')), 100);
+            }),
+        ]);
+
+        expect(returnCalled).toBe(true);
+        expect(result.completed).toBe(false);
+        expect(result.error).toBe('request failed without failed status');
+        expect(result.failure).toMatchObject({
+            operation: 'result',
+            request_id: 'req_terminal_error_only',
+            terminal: true,
+            recoverable: false,
+        });
+    });
+
+    it('preserves operation failure metadata when a terminal error follows failed status', async () => {
+        async function* stream(): AsyncGenerator<ProviderStreamEvent> {
+            yield {
+                type: 'operation_status',
+                operation: 'request',
+                status: 'failed',
+                request_id: 'req_123',
+                reason: 'terminal_error',
+                error: 'request failed',
+                recoverable: false,
+                terminal: true,
+            } as ProviderStreamEvent;
+            yield {
+                type: 'error',
+                request_id: 'req_123',
+                error: 'request failed',
+                recoverable: false,
+            } as ProviderStreamEvent;
+        }
+
+        const result = await ensembleResult(stream());
+
+        expect(result.completed).toBe(false);
+        expect(result.error).toBe('request failed');
+        expect(result.failure).toMatchObject({
+            operation: 'request',
+            request_id: 'req_123',
+            reason: 'terminal_error',
+            terminal: true,
+            recoverable: false,
+        });
+    });
+
+    it('captures thinking from message_complete events without a preceding message_start', async () => {
+        async function* stream(): AsyncGenerator<ProviderStreamEvent> {
+            yield {
+                type: 'message_complete',
+                message_id: 'msg_thinking',
+                content: 'final answer',
+                thinking_content: 'chain of thought summary',
+                thinking_signature: 'sig_123',
+            } as ProviderStreamEvent;
+            yield { type: 'stream_end' } as ProviderStreamEvent;
+        }
+
+        const result = await ensembleResult(stream());
+
+        expect(result.message).toBe('final answer');
+        expect(result.thinking).toEqual({
+            content: 'chain of thought summary',
+            signature: 'sig_123',
+        });
+    });
+
+    it('times out a stalled image provider via ImageGenerationOpts.timeout_ms', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'test-image-provider',
+            createImage: vi.fn().mockImplementation(() => new Promise(() => undefined)),
+        } as any);
+
+        const agent: AgentDefinition = { model: 'test-model' };
+        const stream = ensembleImage('Draw a clock', agent, {
+            stream: true,
+            timeout_ms: 25,
+        }) as AsyncGenerator<ProviderStreamEvent>;
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of stream) {
+            events.push(event);
+        }
+
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+        expect(failedStatus).toBeDefined();
+        expect(failedStatus.error).toContain('timed out after 25ms');
+        expect(failedStatus.terminal).toBe(true);
+    });
+
+    it('does not start image generation when already aborted', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createImage = vi.fn().mockResolvedValue(['image-data']);
+        const abortController = new AbortController();
+        abortController.abort();
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'test-image-provider',
+            createImage,
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            abortSignal: abortController.signal,
+        };
+        const stream = ensembleImage('Draw a clock', agent, {
+            stream: true,
+        }) as AsyncGenerator<ProviderStreamEvent>;
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of stream) {
+            events.push(event);
+        }
+
+        expect(createImage).not.toHaveBeenCalled();
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+        expect(failedStatus?.error).toContain('aborted');
+    });
+
+    it('aborts promptly when the signal flips during raceWithAbortAndTimeout startup', async () => {
+        const abortController = new AbortController();
+
+        const result = await Promise.race([
+            raceWithAbortAndTimeout(
+                () => {
+                    abortController.abort();
+                    return new Promise<string>(() => undefined);
+                },
+                {
+                    operationName: 'Image generation',
+                    abortSignal: abortController.signal,
+                    timeoutMs: 1000,
+                }
+            ).then(
+                value => value,
+                error => error
+            ),
+            new Promise(resolve => setTimeout(() => resolve(new Error('raceWithAbortAndTimeout hung during startup')), 50)),
+        ]);
+
+        expect(result).toBeInstanceOf(Error);
+        expect((result as Error).message).toContain('aborted');
+    });
+
+    it('times out a stalled request provider via ModelSettings.timeout_ms', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            await new Promise(() => undefined);
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'test-request-provider',
+            createResponseStream,
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                timeout_ms: 25,
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+        expect(failedStatus).toBeDefined();
+        expect(failedStatus.error).toContain('timed out after 25ms');
+        expect(failedStatus.terminal).toBe(true);
+        expect(failedStatus.recoverable).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+        expect(createResponseStream).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry after a stream error arrives after tool_start', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-1',
+                    call_id: 'call-1',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+            yield {
+                type: 'error',
+                error: 'provider ended with malformed later tool call',
+            } as ProviderStreamEvent;
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'tool-error-provider',
+            createResponseStream,
+        } as any);
+
+        const toolFn = vi.fn().mockImplementation(async () => {
+            await new Promise(resolve => setTimeout(resolve, 75));
+            return 'sunny';
+        });
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: toolFn,
+                },
+            ],
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        expect(createResponseStream).toHaveBeenCalledTimes(1);
+        expect(toolFn).toHaveBeenCalledTimes(1);
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+        expect(errorEvent?.recoverable).toBe(false);
+        expect(failedStatus?.terminal).toBe(true);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('uses bounded tool finalization after a terminal provider error event', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-terminal-error',
+                    call_id: 'call-terminal-error',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+            yield {
+                type: 'error',
+                error: 'provider emitted malformed arguments for a later tool call',
+                recoverable: false,
+            } as ProviderStreamEvent;
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'terminal-error-provider',
+            createResponseStream,
+        } as any);
+
+        const toolFn = vi.fn().mockImplementation(
+            async (_args?: unknown, abortSignal?: AbortSignal) =>
+                new Promise((_, reject) => {
+                    abortSignal?.addEventListener(
+                        'abort',
+                        () => reject(new Error('tool aborted after terminal provider failure')),
+                        { once: true }
+                    );
+                })
+        );
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: toolFn,
+                    injectAbortSignal: true,
+                },
+            ],
+        };
+
+        const events = await Promise.race([
+            (async () => {
+                const collected: ProviderStreamEvent[] = [];
+                for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+                    collected.push(event);
+                }
+                return collected;
+            })(),
+            new Promise<ProviderStreamEvent[]>((_, reject) => {
+                setTimeout(() => reject(new Error('ensembleRequest hung after terminal provider error event')), 250);
+            }),
+        ]);
+
+        const toolDone = events.find(event => event.type === 'tool_done') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(toolDone?.result?.error).toContain('Operation was aborted');
+        expect(failedStatus?.error).toContain('malformed arguments');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('uses bounded tool finalization after a post-tool provider error is upgraded to terminal', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-upgraded-terminal-error',
+                    call_id: 'call-upgraded-terminal-error',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+            yield {
+                type: 'error',
+                error: 'provider emitted a plain post-tool error',
+            } as ProviderStreamEvent;
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'upgraded-terminal-error-provider',
+            createResponseStream,
+        } as any);
+
+        const toolFn = vi.fn().mockImplementation(
+            async (_args?: unknown, abortSignal?: AbortSignal) =>
+                new Promise((_, reject) => {
+                    abortSignal?.addEventListener(
+                        'abort',
+                        () => reject(new Error('tool aborted after upgraded terminal provider failure')),
+                        { once: true }
+                    );
+                })
+        );
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: toolFn,
+                    injectAbortSignal: true,
+                },
+            ],
+        };
+
+        const events = await Promise.race([
+            (async () => {
+                const collected: ProviderStreamEvent[] = [];
+                for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+                    collected.push(event);
+                }
+                return collected;
+            })(),
+            new Promise<ProviderStreamEvent[]>((_, reject) => {
+                setTimeout(() => reject(new Error('ensembleRequest hung after upgraded terminal provider error event')), 250);
+            }),
+        ]);
+
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        const toolDone = events.find(event => event.type === 'tool_done') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(errorEvent?.recoverable).toBe(false);
+        expect(toolDone?.result?.error).toContain('Operation was aborted');
+        expect(failedStatus?.error).toContain('plain post-tool error');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('does not report completion when a terminal tool succeeds before a malformed later tool error', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-terminal',
+                    call_id: 'call-terminal',
+                    type: 'function',
+                    function: {
+                        name: 'task_complete',
+                        arguments: '{"answer":"done"}',
+                    },
+                },
+            } as ProviderStreamEvent;
+            yield {
+                type: 'error',
+                error: 'provider emitted malformed arguments for a later tool call',
+                recoverable: false,
+            } as ProviderStreamEvent;
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'terminal-tool-error-provider',
+            createResponseStream,
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'task_complete',
+                            description: 'Finish the task',
+                            parameters: {
+                                type: 'object',
+                                properties: {
+                                    answer: { type: 'string' },
+                                },
+                            },
+                        },
+                    },
+                    function: vi.fn().mockResolvedValue('done'),
+                },
+            ],
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+        expect(failedStatus?.terminal).toBe(true);
+        expect(failedStatus?.error).toContain('malformed arguments');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('retries recoverable thrown stream errors even after tool_start events', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        let attempts = 0;
+        let retryMessages: any[] = [];
+
+        const createResponseStream = vi.fn().mockImplementation(async function* (messages: any[]) {
+            attempts += 1;
+
+            if (attempts === 1) {
+                yield {
+                    type: 'tool_start',
+                    tool_call: {
+                        id: 'tool-retry',
+                        call_id: 'call-retry',
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            arguments: '{}',
+                        },
+                    },
+                } as ProviderStreamEvent;
+
+                throw new Error('temporary transport failure');
+            }
+
+            retryMessages = messages;
+
+            yield {
+                type: 'message_complete',
+                message_id: 'msg_recovered',
+                content: 'Recovered after retry',
+            } as ProviderStreamEvent;
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'tool-throw-retry-provider',
+            createResponseStream,
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: vi.fn().mockImplementation(async () => {
+                        await new Promise(resolve => setTimeout(resolve, 75));
+                        return 'sunny';
+                    }),
+                },
+            ],
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const toolDone = events.find(event => event.type === 'tool_done') as any;
+        const retryToolOutput = retryMessages.find(
+            message => message.type === 'function_call_output' && message.call_id === 'call-retry'
+        );
+
+        expect(createResponseStream).toHaveBeenCalledTimes(2);
+        expect(agent.tools?.[0] && 'function' in agent.tools[0] ? agent.tools[0].function : undefined).toHaveBeenCalledTimes(1);
+        expect(toolDone?.result?.output).toBe('sunny');
+        expect(toolDone?.result?.error).toBeUndefined();
+        expect(retryToolOutput?.output).toBe('sunny');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(true);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(true);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'failed')).toBe(false);
+    });
+
+    it('awaits started tools and emits tool_done before timing out the request stream', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-1',
+                    call_id: 'call-1',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+
+            await new Promise(() => undefined);
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'timed-tool-provider',
+            createResponseStream,
+        } as any);
+
+        const toolFn = vi.fn().mockImplementation(async () => {
+            await new Promise(resolve => setTimeout(resolve, 15));
+            return 'sunny';
+        });
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                timeout_ms: 5,
+            },
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: toolFn,
+                },
+            ],
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        expect(createResponseStream).toHaveBeenCalledTimes(1);
+        expect(toolFn).toHaveBeenCalledTimes(1);
+        expect(events.some(event => event.type === 'tool_done')).toBe(true);
+        const toolDone = events.find(event => event.type === 'tool_done') as any;
+        expect(toolDone?.result?.output).toBe('sunny');
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+        expect(failedStatus?.error).toContain('timed out after 5ms');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+    });
+
+    it('surfaces request timeout even when a started tool would otherwise never settle', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-hang',
+                    call_id: 'call-hang',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+
+            await new Promise(() => undefined);
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'hung-tool-provider',
+            createResponseStream,
+        } as any);
+
+        const toolFn = vi.fn().mockImplementation(
+            async (_args?: unknown, abortSignal?: AbortSignal) =>
+                new Promise((_, reject) => {
+                    abortSignal?.addEventListener(
+                        'abort',
+                        () => reject(new Error('tool aborted after request failure')),
+                        { once: true }
+                    );
+                })
+        );
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                timeout_ms: 5,
+            },
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: toolFn,
+                    injectAbortSignal: true,
+                },
+            ],
+        };
+
+        const events = await Promise.race([
+            (async () => {
+                const collected: ProviderStreamEvent[] = [];
+                for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+                    collected.push(event);
+                }
+                return collected;
+            })(),
+            new Promise<ProviderStreamEvent[]>((_, reject) => {
+                setTimeout(() => reject(new Error('ensembleRequest hung after timing out a started tool')), 250);
+            }),
+        ]);
+
+        const toolDone = events.find(event => event.type === 'tool_done') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(toolDone?.result?.error).toContain('Operation was aborted');
+        expect(failedStatus?.error).toContain('timed out after 5ms');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+    });
+
+    it('preserves the terminal stream failure when onToolCall throws during failed-round finalization', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-hook-failure',
+                    call_id: 'call-hook-failure',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+
+            await new Promise(() => undefined);
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'hook-failure-provider',
+            createResponseStream,
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                timeout_ms: 5,
+            },
+            onToolCall: vi.fn().mockRejectedValue(new Error('tool hook failed')),
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: vi.fn().mockResolvedValue('sunny'),
+                },
+            ],
+        };
+
+        const events = await Promise.race([
+            (async () => {
+                const collected: ProviderStreamEvent[] = [];
+                for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+                    collected.push(event);
+                }
+                return collected;
+            })(),
+            new Promise<ProviderStreamEvent[]>((_, reject) => {
+                setTimeout(() => reject(new Error('ensembleRequest masked the terminal stream failure')), 250);
+            }),
+        ]);
+
+        const toolDone = events.find(event => event.type === 'tool_done') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(toolDone?.result?.error).toContain('tool hook failed');
+        expect(failedStatus?.error).toContain('timed out after 5ms');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+    });
+
+    it('emits a synthetic failed tool output when bounded finalization gives up on a started tool', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+        const { runningToolTracker } = await import('../utils/running_tool_tracker.js');
+        const abortSpy = vi.spyOn(runningToolTracker, 'abortRunningTool').mockImplementation(() => {});
+        const createResponseStream = vi.fn().mockImplementation(async function* () {
+            yield {
+                type: 'tool_start',
+                tool_call: {
+                    id: 'tool-slow',
+                    call_id: 'call-slow',
+                    type: 'function',
+                    function: {
+                        name: 'lookup_weather',
+                        arguments: '{}',
+                    },
+                },
+            } as ProviderStreamEvent;
+            yield {
+                type: 'error',
+                error: 'terminal provider failure after tool start',
+                recoverable: false,
+            } as ProviderStreamEvent;
+        });
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'terminal-tool-failure-provider',
+            createResponseStream,
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            tools: [
+                {
+                    definition: {
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            description: 'Lookup weather',
+                            parameters: { type: 'object', properties: {} },
+                        },
+                    },
+                    function: vi.fn().mockImplementation(async () => new Promise(() => undefined)),
+                },
+            ],
+        };
+
+        try {
+            const events: ProviderStreamEvent[] = [];
+            for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+                events.push(event);
+            }
+
+            const toolDone = events.find(event => event.type === 'tool_done') as any;
+            const functionOutput = events.find(
+                event => event.type === 'response_output' && (event as any).message?.type === 'function_call_output'
+            ) as any;
+            const failedStatus = events.find(
+                event => event.type === 'operation_status' && (event as any).status === 'failed'
+            ) as any;
+
+            expect(createResponseStream).toHaveBeenCalledTimes(1);
+            expect(toolDone?.result?.error).toContain('did not finish before request finalization');
+            expect(functionOutput?.message?.output).toContain(
+                'Tool execution failed: Tool did not finish before request finalization'
+            );
+            expect(functionOutput?.message?.output.startsWith('undefined')).toBe(false);
+            expect(failedStatus?.error).toContain('terminal provider failure after tool start');
+            expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+            expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+        } finally {
+            abortSpy.mockRestore();
+            runningToolTracker.clear();
+        }
+    });
+
+    it('fails immediately when a provider stream ends without output', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'empty-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                // Intentionally empty.
+            }),
+        } as any);
+
+        const agent: AgentDefinition = { model: 'test-model' };
+        const events: ProviderStreamEvent[] = [];
+
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(errorEvent?.error).toContain('ended the stream without any terminal content');
+        expect(failedStatus?.terminal).toBe(true);
+        expect(failedStatus?.attempt).toBe(1);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('does not treat reasoning-only completions as terminal output', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'reasoning-only-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'reasoning-only',
+                    content: '',
+                    thinking_content: 'internal thoughts',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = { model: 'test-model' };
+        const events: ProviderStreamEvent[] = [];
+
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        expect(errorEvent?.error).toContain('ended the stream without any terminal content');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('accepts reasoning-only structured-output frames before a final JSON message', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'reasoning-json-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'reasoning',
+                    content: '',
+                    thinking_content: 'working through it',
+                } as ProviderStreamEvent;
+                yield {
+                    type: 'message_complete',
+                    message_id: 'result',
+                    content: '{"answer":"done"}',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                json_schema: {
+                    name: 'result',
+                    type: 'json_schema',
+                    strict: true,
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            answer: { type: 'string' },
+                        },
+                        required: ['answer'],
+                        additionalProperties: false,
+                    },
+                },
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        expect(events.some(event => event.type === 'error')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'failed')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(true);
+        const responseOutputs = events.filter(event => event.type === 'response_output') as any[];
+        expect(responseOutputs.some(event => event.message?.content === '{"answer":"done"}')).toBe(true);
+    });
+
+    it('treats invalid structured output as a terminal request failure', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'structured-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'msg_invalid_json',
+                    content: 'not valid json',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                json_schema: {
+                    name: 'result',
+                    type: 'json_schema',
+                    strict: true,
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            answer: { type: 'string' },
+                        },
+                        required: ['answer'],
+                        additionalProperties: false,
+                    },
+                },
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(errorEvent?.error).toContain('Structured output was not valid JSON');
+        expect(failedStatus?.terminal).toBe(true);
+        expect(failedStatus?.recoverable).toBe(false);
+        expect(failedStatus?.attempt).toBe(1);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('does not turn non-strict structured-output mismatches into terminal request failures', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'non-strict-structured-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'msg_non_strict_json',
+                    content: 'not valid json',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                json_schema: {
+                    name: 'result',
+                    type: 'json_schema',
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            answer: { type: 'string' },
+                        },
+                        required: ['answer'],
+                        additionalProperties: false,
+                    },
+                },
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        expect(events.some(event => event.type === 'error')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'failed')).toBe(false);
+        const responseOutputs = events.filter(event => event.type === 'response_output') as any[];
+        expect(responseOutputs.some(event => event.message?.content === 'not valid json')).toBe(true);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(true);
+    });
+
+    it('treats invalid structured-output regex patterns as terminal schema validation failures', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'invalid-pattern-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'msg_regex_json',
+                    content: '{"answer":"done"}',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                json_schema: {
+                    name: 'result',
+                    type: 'json_schema',
+                    strict: true,
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            answer: {
+                                type: 'string',
+                                pattern: '[invalid',
+                            },
+                        },
+                        required: ['answer'],
+                        additionalProperties: false,
+                    },
+                },
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        const failedStatus = events.find(event => event.type === 'operation_status' && (event as any).status === 'failed') as any;
+
+        expect(errorEvent?.error).toContain('invalid pattern');
+        expect(errorEvent?.error).toContain('[invalid');
+        expect(failedStatus?.terminal).toBe(true);
+        expect(failedStatus?.recoverable).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'retrying')).toBe(false);
+    });
+
+    it('treats blank structured output as a terminal request failure', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'structured-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'msg_blank_json',
+                    content: '   ',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            modelSettings: {
+                json_schema: {
+                    name: 'result',
+                    type: 'json_schema',
+                    strict: true,
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            answer: { type: 'string' },
+                        },
+                        required: ['answer'],
+                        additionalProperties: false,
+                    },
+                },
+            },
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const errorEvent = events.find(event => event.type === 'error') as any;
+        expect(errorEvent?.error).toContain('ended the stream without any terminal content');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('treats whitespace-only plain-text completions as terminal output', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'plain-text-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'message_complete',
+                    message_id: 'msg_blank_text',
+                    content: '   ',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        expect(events.some(event => event.type === 'error')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'failed')).toBe(false);
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(true);
+        const responseOutput = events.find(event => event.type === 'response_output') as any;
+        expect(responseOutput?.message?.content).toBe('   ');
+    });
+
+    it('fails tool-limited turns instead of reporting completion', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'tool-limit-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* () {
+                yield {
+                    type: 'tool_start',
+                    tool_call: {
+                        id: 'tool-1',
+                        type: 'function',
+                        function: {
+                            name: 'lookup_weather',
+                            arguments: '{}',
+                        },
+                    },
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const agent: AgentDefinition = {
+            model: 'test-model',
+            maxToolCalls: 0,
+        };
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest([{ type: 'message', role: 'user', content: 'Hello' }], agent)) {
+            events.push(event);
+        }
+
+        const failedStatus = events.find(
+            event => event.type === 'operation_status' && (event as any).status === 'failed'
+        ) as any;
+        expect(failedStatus?.reason).toBe('tool_limit_reached');
+        expect(failedStatus?.terminal).toBe(true);
+        expect(failedStatus?.recoverable).toBe(false);
+        expect(failedStatus?.error).toContain('Tool call limit reached (0).');
+        expect(events.some(event => event.type === 'operation_status' && (event as any).status === 'completed')).toBe(false);
+    });
+
+    it('emits a failed outer request status when verification exhausts its attempts', async () => {
+        const { getModelProvider } = await import('../model_providers/model_provider.js');
+
+        vi.mocked(getModelProvider).mockReturnValue({
+            provider_id: 'verification-failure-provider',
+            createResponseStream: vi.fn().mockImplementation(async function* (_messages: any[], _model: string, agent: AgentDefinition) {
+                yield {
+                    type: 'message_complete',
+                    message_id: `${agent.name || 'agent'}-message`,
+                    content:
+                        agent.name === 'verifier_agent'
+                            ? '{"status":"fail","reason":"Missing required details"}'
+                            : 'Candidate response',
+                } as ProviderStreamEvent;
+            }),
+        } as any);
+
+        const events: ProviderStreamEvent[] = [];
+        for await (const event of ensembleRequest(
+            [{ type: 'message', role: 'user', content: 'Hello' }],
+            {
+                model: 'test-model',
+                name: 'main_agent',
+                verifier: {
+                    name: 'verifier_agent',
+                },
+                maxVerificationAttempts: 2,
+            }
+        )) {
+            events.push(event);
+        }
+
+        const outerRequestId = (events.find(event => event.type === 'agent_start') as any)?.request_id;
+        const outerStatuses = events.filter(
+            event => event.type === 'operation_status' && (event as any).request_id === outerRequestId
+        ) as any[];
+
+        expect(outerStatuses.map(event => event.status)).toEqual(['started', 'failed']);
+        expect(outerStatuses[1]?.reason).toBe('verification_failed');
+        expect(outerStatuses[1]?.error).toContain('Verification failed after 2 attempts: Missing required details');
+        expect(outerStatuses.some(event => event.status === 'completed')).toBe(false);
+        expect(
+            events.some(
+                event =>
+                    event.type === 'message_delta' &&
+                    (event as any).content?.includes('❌ Verification failed after 2 attempts: Missing required details')
+            )
+        ).toBe(true);
+    });
+
+    it('clears transient retry errors when ensembleResult later sees completion', async () => {
+        const stream = {
+            events: [
+                {
+                    type: 'operation_status',
+                    operation: 'request',
+                    status: 'retrying',
+                    error: 'temporary failure',
+                    recoverable: true,
+                    terminal: false,
+                },
+                {
+                    type: 'operation_status',
+                    operation: 'request',
+                    status: 'completed',
+                    terminal: true,
+                    will_continue: false,
+                },
+                { type: 'stream_end' },
+            ],
+            async next() {
+                const value = this.events.shift();
+                return value ? { done: false, value } : { done: true, value: undefined };
+            },
+            async return() {
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream);
+        expect(result.completed).toBe(true);
+        expect(result.error).toBeUndefined();
+        expect(result.failure).toBeUndefined();
+    });
+
+    it('does not mark a terminal failure as completed when stream_end arrives', async () => {
+        const stream = {
+            events: [
+                {
+                    type: 'operation_status',
+                    operation: 'request',
+                    status: 'failed',
+                    error: 'terminal failure',
+                    recoverable: false,
+                    terminal: true,
+                },
+                { type: 'stream_end' },
+            ],
+            async next() {
+                const value = this.events.shift();
+                return value ? { done: false, value } : { done: true, value: undefined };
+            },
+            async return() {
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream);
+
+        expect(result.completed).toBe(false);
+        expect(result.error).toBe('terminal failure');
+        expect(result.failure?.terminal).toBe(true);
+    });
+
+    it('marks a stream as completed when only non-terminal errors occurred before stream_end', async () => {
+        const stream = {
+            events: [
+                {
+                    type: 'error',
+                    error: 'temporary warning',
+                    recoverable: true,
+                },
+                { type: 'stream_end' },
+            ],
+            async next() {
+                const value = this.events.shift();
+                return value ? { done: false, value } : { done: true, value: undefined };
+            },
+            async return() {
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream);
+
+        expect(result.completed).toBe(true);
+        expect(result.error).toBe('temporary warning');
+        expect(result.failure).toBeUndefined();
+    });
+
+    it('does not mark error-only streams as completed when they end without stream_end', async () => {
+        const stream = {
+            events: [
+                {
+                    type: 'error',
+                    error: 'provider stream failed',
+                },
+            ],
+            async next() {
+                const value = this.events.shift();
+                return value ? { done: false, value } : { done: true, value: undefined };
+            },
+            async return() {
+                return { done: true, value: undefined };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        } as any as AsyncGenerator<ProviderStreamEvent>;
+
+        const result = await ensembleResult(stream);
+
+        expect(result.completed).toBe(false);
+        expect(result.error).toBe('provider stream failed');
+        expect(result.failure).toBeUndefined();
+    });
+
+    it('preserves recoverable false on terminal error events', () => {
+        const event = toTerminalErrorEvent({
+            error: 'terminal failure',
+            recoverable: undefined,
+        });
+
+        expect(event.recoverable).toBe(false);
+    });
+});

--- a/test/provider_chat_failure_paths.test.ts
+++ b/test/provider_chat_failure_paths.test.ts
@@ -1,0 +1,1046 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAIChat } from '../model_providers/openai_chat.js';
+import { OpenAIProvider } from '../model_providers/openai.js';
+import { ClaudeProvider } from '../model_providers/claude.js';
+import { validateJsonResponseContent } from '../utils/json_schema.js';
+
+async function collectEvents(stream: AsyncIterable<any>): Promise<any[]> {
+    const events: any[] = [];
+    for await (const event of stream) {
+        events.push(event);
+    }
+    return events;
+}
+
+function emptyStream() {
+    return {
+        async *[Symbol.asyncIterator]() {
+            // No-op stream.
+        },
+    };
+}
+
+describe('provider chat failure paths', () => {
+    it('preserves strict json_schema payloads for chat providers', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        const create = vi.fn().mockResolvedValue(emptyStream());
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create,
+                },
+            },
+        };
+
+
+        const schema = {
+            type: 'object',
+            properties: {
+                answer: {
+                    type: 'string',
+                    optional: true,
+                    minLength: 3,
+                    pattern: '^[a-z]+$',
+                    default: 'nope',
+                },
+                score: {
+                    type: 'number',
+                    minimum: 1,
+                    maximum: 5,
+                    multipleOf: 0.5,
+                },
+                tags: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    minItems: 1,
+                    maxItems: 3,
+                },
+            },
+            required: ['score'],
+            additionalProperties: false,
+        };
+
+        await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Return JSON' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-grok-json-schema',
+                    modelSettings: {
+                        json_schema: {
+                            name: 'result',
+                            type: 'json_schema',
+                            strict: true,
+                            schema,
+                        },
+                    },
+                } as any
+            )
+        );
+
+        const requestParams = create.mock.calls.at(0)?.[0];
+        expect(requestParams?.response_format?.json_schema?.schema).toEqual(schema);
+    });
+
+    it('preserves explicit required arrays in caller-provided json_schema', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        const create = vi.fn().mockResolvedValue(emptyStream());
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create,
+                },
+            },
+        };
+
+        await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Return JSON' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-grok-standard-json-schema',
+                    modelSettings: {
+                        json_schema: {
+                            name: 'result',
+                            type: 'json_schema',
+                            strict: true,
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    answer: { type: 'string' },
+                                    note: { type: 'string' },
+                                },
+                                required: ['answer'],
+                                additionalProperties: false,
+                            },
+                        },
+                    },
+                } as any
+            )
+        );
+
+        const requestParams = create.mock.calls.at(0)?.[0];
+        expect(requestParams?.response_format?.json_schema?.schema.required).toEqual(['answer']);
+    });
+
+    it('preserves non-strict json_schema payloads for chat providers', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        const create = vi.fn().mockResolvedValue(emptyStream());
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create,
+                },
+            },
+        };
+
+        const schema = {
+            type: 'object',
+            properties: {
+                answer: {
+                    type: 'string',
+                    minLength: 3,
+                    pattern: '^[a-z]+$',
+                    default: 'abc',
+                },
+                metadata: {
+                    type: 'object',
+                    additionalProperties: {
+                        type: 'string',
+                    },
+                },
+            },
+        };
+
+        await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Return JSON' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-grok-non-strict-json-schema',
+                    modelSettings: {
+                        json_schema: {
+                            name: 'result',
+                            type: 'json_schema',
+                            schema,
+                        },
+                    },
+                } as any
+            )
+        );
+
+        const requestParams = create.mock.calls.at(0)?.[0];
+        expect(requestParams?.response_format?.json_schema?.schema).toEqual(schema);
+    });
+
+    it('preserves oneOf branch requirements when normalizing OpenAI response schemas', async () => {
+        const provider = new OpenAIProvider();
+        const create = vi.fn().mockResolvedValue(emptyStream());
+        (provider as any)._client = {
+            responses: {
+                create,
+            },
+        };
+
+        await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Return JSON' }] as any,
+                'gpt-4.1-mini',
+                {
+                    agent_id: 'test-openai-oneof-json-schema',
+                    modelSettings: {
+                        json_schema: {
+                            name: 'result',
+                            type: 'json_schema',
+                            strict: true,
+                            schema: {
+                                oneOf: [
+                                    {
+                                        type: 'object',
+                                        properties: {
+                                            kind: { const: 'weather' },
+                                            city: { type: 'string' },
+                                            units: { type: 'string', optional: true },
+                                        },
+                                    },
+                                    {
+                                        type: 'object',
+                                        properties: {
+                                            kind: { const: 'time' },
+                                            timezone: { type: 'string' },
+                                        },
+                                        required: ['kind', 'timezone'],
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                } as any
+            )
+        );
+
+        const requestParams = create.mock.calls.at(0)?.[0];
+        expect(requestParams?.text?.format?.schema).toEqual({
+            anyOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        kind: { const: 'weather' },
+                        city: { type: 'string' },
+                        units: { type: 'string' },
+                    },
+                    additionalProperties: false,
+                    required: ['kind', 'city', 'units'],
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        kind: { const: 'time' },
+                        timezone: { type: 'string' },
+                    },
+                    additionalProperties: false,
+                    required: ['kind', 'timezone'],
+                },
+            ],
+        });
+    });
+
+    it('preserves optional tool properties in OpenAI tool schemas', async () => {
+        const provider = new OpenAIProvider();
+        const create = vi.fn().mockResolvedValue(emptyStream());
+        (provider as any)._client = {
+            responses: {
+                create,
+            },
+        };
+
+        await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tool' }] as any,
+                'gpt-4.1-mini',
+                {
+                    agent_id: 'test-openai-tool-optional-required',
+                    tools: [
+                        {
+                            definition: {
+                                type: 'function',
+                                function: {
+                                    name: 'lookup_weather',
+                                    description: 'Lookup weather',
+                                    parameters: {
+                                        type: 'object',
+                                        properties: {
+                                            city: { type: 'string' },
+                                            units: { type: 'string', optional: true },
+                                        },
+                                    },
+                                },
+                            },
+                            function: vi.fn(),
+                        },
+                    ],
+                } as any
+            )
+        );
+
+        const requestParams = create.mock.calls.at(0)?.[0];
+        expect(requestParams?.tools?.[0]?.parameters).toMatchObject({
+            type: 'object',
+            additionalProperties: false,
+            required: ['city'],
+        });
+    });
+
+    it('preserves explicit required subsets in OpenAI tool schemas', async () => {
+        const provider = new OpenAIProvider();
+        const create = vi.fn().mockResolvedValue(emptyStream());
+        (provider as any)._client = {
+            responses: {
+                create,
+            },
+        };
+
+        await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tool' }] as any,
+                'gpt-4.1-mini',
+                {
+                    agent_id: 'test-openai-tool-explicit-required',
+                    tools: [
+                        {
+                            definition: {
+                                type: 'function',
+                                function: {
+                                    name: 'lookup_weather',
+                                    description: 'Lookup weather',
+                                    parameters: {
+                                        type: 'object',
+                                        properties: {
+                                            city: { type: 'string' },
+                                            units: { type: 'string' },
+                                            locale: { type: 'string', optional: true },
+                                        },
+                                        required: ['city'],
+                                    },
+                                },
+                            },
+                            function: vi.fn(),
+                        },
+                    ],
+                } as any
+            )
+        );
+
+        const requestParams = create.mock.calls.at(0)?.[0];
+        expect(requestParams?.tools?.[0]?.parameters).toMatchObject({
+            type: 'object',
+            additionalProperties: false,
+            required: ['city'],
+        });
+    });
+
+    it('emits an error instead of a partial tool call when OpenAI responses stop mid-tool', async () => {
+        const provider = new OpenAIProvider();
+        (provider as any)._client = {
+            responses: {
+                create: vi.fn().mockResolvedValue({
+                    async *[Symbol.asyncIterator]() {
+                        yield {
+                            type: 'response.output_item.added',
+                            output_index: 0,
+                            item: {
+                                type: 'function_call',
+                                id: 'fc_1',
+                                call_id: 'call_1',
+                                name: 'lookup_weather',
+                            },
+                        };
+                    },
+                }),
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tool' }] as any,
+                'gpt-5-mini',
+                {
+                    agent_id: 'test-openai-incomplete-tool',
+                } as any
+            )
+        );
+
+        expect(events.some(event => event.type === 'tool_start')).toBe(false);
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(errorEvent?.error).toContain('incomplete tool call arguments');
+        expect(errorEvent?.error).toContain('lookup_weather');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('marks incomplete OpenAI multi-tool streams as terminal after valid tool starts', async () => {
+        const provider = new OpenAIProvider();
+        (provider as any)._client = {
+            responses: {
+                create: vi.fn().mockResolvedValue({
+                    async *[Symbol.asyncIterator]() {
+                        yield {
+                            type: 'response.output_item.added',
+                            output_index: 0,
+                            item: {
+                                type: 'function_call',
+                                id: 'fc_1',
+                                call_id: 'call_1',
+                                name: 'lookup_weather',
+                            },
+                        };
+                        yield {
+                            type: 'response.output_item.added',
+                            output_index: 1,
+                            item: {
+                                type: 'function_call',
+                                id: 'fc_2',
+                                call_id: 'call_2',
+                                name: 'lookup_time',
+                            },
+                        };
+                        yield {
+                            type: 'response.function_call_arguments.done',
+                            item_id: 'fc_1',
+                            arguments: '{"city":"Paris"}',
+                        };
+                    },
+                }),
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tools' }] as any,
+                'gpt-5-mini',
+                {
+                    agent_id: 'test-openai-mixed-tool-stream',
+                } as any
+            )
+        );
+
+        const toolStart = events.find(event => event.type === 'tool_start');
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(toolStart?.tool_call?.function?.name).toBe('lookup_weather');
+        expect(errorEvent?.error).toContain('lookup_time');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('marks malformed Claude tool arguments as terminal after earlier tool starts', async () => {
+        const provider = new ClaudeProvider('test-key');
+        (provider as any)._client = {
+            messages: {
+                create: vi.fn().mockResolvedValue({
+                    async *[Symbol.asyncIterator]() {
+                        yield {
+                            type: 'content_block_start',
+                            content_block: {
+                                type: 'tool_use',
+                                id: 'tool_1',
+                                name: 'lookup_weather',
+                                input: {},
+                            },
+                        };
+                        yield {
+                            type: 'content_block_stop',
+                            content_block: {
+                                type: 'tool_use',
+                            },
+                        };
+                        yield {
+                            type: 'content_block_start',
+                            content_block: {
+                                type: 'tool_use',
+                                id: 'tool_2',
+                                name: 'lookup_time',
+                                input: {},
+                            },
+                        };
+                        yield {
+                            type: 'content_block_delta',
+                            delta: {
+                                type: 'input_json_delta',
+                                partial_json: '{"timezone":"UTC"',
+                            },
+                        };
+                        yield {
+                            type: 'content_block_stop',
+                            content_block: {
+                                type: 'tool_use',
+                            },
+                        };
+                    },
+                }),
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tools' }] as any,
+                'claude-sonnet-4-20250514',
+                {
+                    agent_id: 'test-claude-mixed-tool-stream',
+                } as any
+            )
+        );
+
+        const toolStart = events.find(event => event.type === 'tool_start');
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(toolStart?.tool_call?.function?.name).toBe('lookup_weather');
+        expect(errorEvent?.error).toContain('lookup_time');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('marks malformed OpenAIChat tool arguments as terminal', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create: vi.fn().mockResolvedValue({
+                        async *[Symbol.asyncIterator]() {
+                            yield {
+                                id: 'chatcmpl-malformed',
+                                choices: [
+                                    {
+                                        index: 0,
+                                        delta: {
+                                            tool_calls: [
+                                                {
+                                                    index: 0,
+                                                    id: 'call_1',
+                                                    type: 'function',
+                                                    function: {
+                                                        name: 'lookup_weather',
+                                                        arguments: '{"city":"Paris"',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        finish_reason: 'tool_calls',
+                                    },
+                                ],
+                            };
+                        },
+                    }),
+                },
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tool' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-openai-chat-malformed-tool',
+                } as any
+            )
+        );
+
+        expect(events.some(event => event.type === 'tool_start')).toBe(false);
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(errorEvent?.error).toContain('malformed tool arguments');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('marks OpenAIChat unparsed tool-call finishes as terminal', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create: vi.fn().mockResolvedValue({
+                        async *[Symbol.asyncIterator]() {
+                            yield {
+                                id: 'chatcmpl-no-tools',
+                                choices: [
+                                    {
+                                        index: 0,
+                                        delta: {},
+                                        finish_reason: 'tool_calls',
+                                    },
+                                ],
+                            };
+                        },
+                    }),
+                },
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tool' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-openai-chat-no-parsed-tools',
+                } as any
+            )
+        );
+
+        expect(events.some(event => event.type === 'tool_start')).toBe(false);
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(errorEvent?.error).toContain('none were parsed correctly');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('does not start earlier valid OpenAIChat tool calls once a sibling is malformed', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create: vi.fn().mockResolvedValue({
+                        async *[Symbol.asyncIterator]() {
+                            yield {
+                                id: 'chatcmpl-mixed-tools',
+                                choices: [
+                                    {
+                                        index: 0,
+                                        delta: {
+                                            tool_calls: [
+                                                {
+                                                    index: 0,
+                                                    id: 'call_1',
+                                                    type: 'function',
+                                                    function: {
+                                                        name: 'lookup_weather',
+                                                        arguments: '{"city":"Paris"}',
+                                                    },
+                                                },
+                                                {
+                                                    index: 1,
+                                                    id: 'call_2',
+                                                    type: 'function',
+                                                    function: {
+                                                        name: 'lookup_time',
+                                                        arguments: '{"timezone":"UTC"',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        finish_reason: 'tool_calls',
+                                    },
+                                ],
+                            };
+                        },
+                    }),
+                },
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tools' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-openai-chat-mixed-tools',
+                } as any
+            )
+        );
+
+        const toolStart = events.find(event => event.type === 'tool_start');
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(toolStart).toBeUndefined();
+        expect(errorEvent?.error).toContain('lookup_time');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('does not start later valid OpenAIChat tool calls once a sibling is malformed', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create: vi.fn().mockResolvedValue({
+                        async *[Symbol.asyncIterator]() {
+                            yield {
+                                id: 'chatcmpl-mixed-tools-later-valid',
+                                choices: [
+                                    {
+                                        index: 0,
+                                        delta: {
+                                            tool_calls: [
+                                                {
+                                                    index: 0,
+                                                    id: 'call_1',
+                                                    type: 'function',
+                                                    function: {
+                                                        name: 'lookup_weather',
+                                                        arguments: '{"city":"Paris"}',
+                                                    },
+                                                },
+                                                {
+                                                    index: 1,
+                                                    id: 'call_2',
+                                                    type: 'function',
+                                                    function: {
+                                                        name: 'lookup_time',
+                                                        arguments: '{"timezone":"UTC"',
+                                                    },
+                                                },
+                                                {
+                                                    index: 2,
+                                                    id: 'call_3',
+                                                    type: 'function',
+                                                    function: {
+                                                        name: 'lookup_forecast',
+                                                        arguments: '{"days":3}',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                        finish_reason: 'tool_calls',
+                                    },
+                                ],
+                            };
+                        },
+                    }),
+                },
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Call the tools' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-openai-chat-later-valid-tools',
+                } as any
+            )
+        );
+
+        const toolStarts = events.filter(event => event.type === 'tool_start');
+        const toolNames = toolStarts.map(event => event.tool_call?.function?.name);
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(toolNames).toEqual([]);
+        expect(errorEvent?.error).toContain('lookup_time');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('marks max_tokens truncation errors as terminal in OpenAIChat streams', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create: vi.fn().mockResolvedValue({
+                        async *[Symbol.asyncIterator]() {
+                            yield {
+                                id: 'chatcmpl-truncated',
+                                choices: [
+                                    {
+                                        index: 0,
+                                        delta: {
+                                            content: 'partial answer',
+                                        },
+                                        finish_reason: 'length',
+                                    },
+                                ],
+                            };
+                        },
+                    }),
+                },
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Answer briefly' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-openai-chat-finish-length',
+                } as any
+            )
+        );
+
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(errorEvent?.error).toContain('Response truncated (max_tokens)');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('marks non-stop OpenAIChat finish reasons as terminal', async () => {
+        const provider = new OpenAIChat('xai', 'xai-test', 'https://api.x.ai/v1');
+        (provider as any)._client = {
+            chat: {
+                completions: {
+                    create: vi.fn().mockResolvedValue({
+                        async *[Symbol.asyncIterator]() {
+                            yield {
+                                id: 'chatcmpl-content-filter',
+                                choices: [
+                                    {
+                                        index: 0,
+                                        delta: {
+                                            content: 'blocked answer',
+                                        },
+                                        finish_reason: 'content_filter',
+                                    },
+                                ],
+                            };
+                        },
+                    }),
+                },
+            },
+        };
+
+        const events = await collectEvents(
+            provider.createResponseStream(
+                [{ type: 'message', role: 'user', content: 'Answer briefly' }] as any,
+                'grok-4-fast-reasoning',
+                {
+                    agent_id: 'test-openai-chat-finish-filter',
+                } as any
+            )
+        );
+
+        const errorEvent = events.find(event => event.type === 'error');
+        expect(errorEvent?.error).toContain('Response stopped due to: content_filter');
+        expect(errorEvent?.recoverable).toBe(false);
+    });
+
+    it('rejects extra keys for closed objects without explicit properties', () => {
+        const validation = validateJsonResponseContent('{"unexpected":true}', {
+            type: 'object',
+            additionalProperties: false,
+        });
+
+        expect(validation.ok).toBe(false);
+        if (!validation.ok) {
+            expect(validation.error).toContain('unexpected');
+            expect(validation.error).toContain('not allowed');
+        }
+    });
+
+    it('accepts valid anyOf object variants when top-level schema is closed', () => {
+        const validation = validateJsonResponseContent('{"kind":"weather","city":"Paris"}', {
+            type: 'object',
+            anyOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        kind: { const: 'weather' },
+                        city: { type: 'string' },
+                    },
+                    required: ['kind', 'city'],
+                    additionalProperties: false,
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        kind: { const: 'time' },
+                        timezone: { type: 'string' },
+                    },
+                    required: ['kind', 'timezone'],
+                    additionalProperties: false,
+                },
+            ],
+            additionalProperties: false,
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
+    it('does not infer required keys from plain json_schema properties during structured-output validation', () => {
+        const validation = validateJsonResponseContent('{"optionalField":"present"}', {
+            type: 'object',
+            properties: {
+                requiredField: { type: 'string' },
+                optionalField: { type: 'string', optional: true },
+            },
+            additionalProperties: false,
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
+    it('honors explicit required keys even without local properties', () => {
+        const validation = validateJsonResponseContent('{"optionalField":"present"}', {
+            type: 'object',
+            required: ['answer'],
+            additionalProperties: {
+                type: 'string',
+            },
+        });
+
+        expect(validation.ok).toBe(false);
+        if (!validation.ok) {
+            expect(validation.error).toContain('answer');
+            expect(validation.error).toContain('required');
+        }
+    });
+
+    it('validates tuple arrays against per-index schemas', () => {
+        const validation = validateJsonResponseContent('["ok","not-an-int"]', {
+            type: 'array',
+            items: [{ type: 'string' }, { type: 'integer' }],
+        });
+
+        expect(validation.ok).toBe(false);
+        if (!validation.ok) {
+            expect(validation.error).toContain('$[1]');
+            expect(validation.error).toContain('integer');
+        }
+    });
+
+    it('validates numeric multipleOf constraints', () => {
+        const invalidValidation = validateJsonResponseContent('0.3', {
+            type: 'number',
+            multipleOf: 0.5,
+        });
+
+        expect(invalidValidation.ok).toBe(false);
+        if (!invalidValidation.ok) {
+            expect(invalidValidation.error).toContain('multiple of 0.5');
+        }
+
+        const validValidation = validateJsonResponseContent('1.5', {
+            type: 'number',
+            multipleOf: 0.5,
+        });
+
+        expect(validValidation.ok).toBe(true);
+    });
+
+    it('matches object const values by structure', () => {
+        const validation = validateJsonResponseContent('{"kind":"weather","units":"c"}', {
+            const: {
+                kind: 'weather',
+                units: 'c',
+            },
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
+    it('matches array enum values by structure', () => {
+        const validation = validateJsonResponseContent('["weather",3]', {
+            enum: [
+                ['weather', 3],
+                ['time', 1],
+            ],
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
+    it('validates schema-valued additionalProperties', () => {
+        const validation = validateJsonResponseContent('{"fixed":"ok","extra":"oops"}', {
+            type: 'object',
+            properties: {
+                fixed: { type: 'string' },
+            },
+            additionalProperties: {
+                type: 'integer',
+            },
+        });
+
+        expect(validation.ok).toBe(false);
+        if (!validation.ok) {
+            expect(validation.error).toContain('extra');
+            expect(validation.error).toContain('integer');
+        }
+    });
+
+    it('collects allowed keys across allOf object branches', () => {
+        const validation = validateJsonResponseContent('{"kind":"weather","city":"Paris"}', {
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        kind: { const: 'weather' },
+                    },
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        city: { type: 'string' },
+                    },
+                },
+            ],
+            additionalProperties: false,
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
+    it('accepts closed allOf object branches when their keys compose the full object', () => {
+        const validation = validateJsonResponseContent('{"a":"x","b":"y"}', {
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        a: { type: 'string' },
+                    },
+                    required: ['a'],
+                    additionalProperties: false,
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        b: { type: 'string' },
+                    },
+                    required: ['b'],
+                    additionalProperties: false,
+                },
+            ],
+        });
+
+        expect(validation.ok).toBe(true);
+    });
+
+    it('does not relax partially closed allOf object branches', () => {
+        const validation = validateJsonResponseContent('{"kind":"weather","city":"Paris"}', {
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        kind: { const: 'weather' },
+                    },
+                    required: ['kind'],
+                    additionalProperties: false,
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        city: { type: 'string' },
+                    },
+                    required: ['city'],
+                },
+            ],
+        });
+
+        expect(validation.ok).toBe(false);
+        if (!validation.ok) {
+            expect(validation.error).toContain('city');
+            expect(validation.error).toContain('not allowed');
+        }
+    });
+
+    it('rejects unexpected keys when allOf object branches are all closed', () => {
+        const validation = validateJsonResponseContent('{"a":"x","b":"y","c":"z"}', {
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        a: { type: 'string' },
+                    },
+                    required: ['a'],
+                    additionalProperties: false,
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        b: { type: 'string' },
+                    },
+                    required: ['b'],
+                    additionalProperties: false,
+                },
+            ],
+        });
+
+        expect(validation.ok).toBe(false);
+        if (!validation.ok) {
+            expect(validation.error).toContain('c');
+            expect(validation.error).toContain('not allowed');
+        }
+    });
+});

--- a/test/provider_image_failure_paths.test.ts
+++ b/test/provider_image_failure_paths.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAIProvider } from '../model_providers/openai.js';
+import { GeminiProvider } from '../model_providers/gemini.js';
+import { GrokProvider } from '../model_providers/grok.js';
+
+describe('provider image failure paths', () => {
+    it('OpenAI rejects non-positive image counts instead of defaulting them to one', async () => {
+        const provider = new OpenAIProvider('sk-test');
+        (provider as any)._client = {
+            images: {
+                generate: vi.fn(),
+            },
+        };
+
+        await expect(
+            provider.createImage('A failed render', 'gpt-image-1.5', { agent_id: 'test-openai' } as any, { n: 0 })
+        ).rejects.toThrow('ImageGenerationOpts.n must be a positive integer');
+
+        expect((provider as any)._client.images.generate).not.toHaveBeenCalled();
+    });
+
+    it('OpenAI throws when the image response is missing image data', async () => {
+        const provider = new OpenAIProvider('sk-test');
+        (provider as any)._client = {
+            images: {
+                generate: vi.fn().mockResolvedValue({ data: [{}] }),
+            },
+        };
+
+        await expect(
+            provider.createImage('A failed render', 'gpt-image-1.5', { agent_id: 'test-openai' } as any, {})
+        ).rejects.toThrow('No image data returned from OpenAI');
+    });
+
+    it('Gemini throws when the image stream completes without image parts', async () => {
+        const provider = new GeminiProvider('test-key');
+        (provider as any)._client = {
+            models: {
+                generateContentStream: vi.fn().mockImplementation(async function* () {
+                    yield {
+                        candidates: [
+                            {
+                                content: {
+                                    parts: [{ text: 'No image here' }],
+                                },
+                            },
+                        ],
+                    };
+                }),
+            },
+        };
+
+        await expect(
+            provider.createImage(
+                'A failed Gemini render',
+                'gemini-2.5-flash-image-preview',
+                { agent_id: 'test-gemini' } as any,
+                {}
+            )
+        ).rejects.toThrow('No images returned from gemini-2.5-flash-image-preview model');
+    });
+
+    it('Grok throws when the API returns no image outputs', async () => {
+        const provider = new GrokProvider();
+        (provider as any)._client = {
+            post: vi.fn().mockResolvedValue({ data: [] }),
+        };
+
+        await expect(
+            provider.createImage(
+                'A failed xAI render',
+                'grok-imagine-image',
+                { agent_id: 'test-grok' } as any,
+                {}
+            )
+        ).rejects.toThrow('xAI image generation returned no images.');
+    });
+});

--- a/types/types.ts
+++ b/types/types.ts
@@ -102,6 +102,7 @@ export interface ModelSettings {
     top_p?: number;
     top_k?: number;
     max_tokens?: number;
+    timeout_ms?: number; // Overall provider request timeout for chat/JSON generation
     stop_sequence?: string;
     seed?: number;
     /** Generic thinking budget in provider-specific units (provider implementations interpret this). */
@@ -300,6 +301,7 @@ export type StreamEventType =
     | 'design_grid'
     | 'console'
     | 'error'
+    | 'operation_status'
     | 'response_output'
     // New types for waiting on tools
     | 'tool_wait_start'
@@ -377,6 +379,25 @@ export interface ToolEvent extends StreamEventBase {
 export interface ErrorEvent extends StreamEventBase {
     type: 'error';
     error: string;
+    code?: string;
+    details?: unknown;
+    recoverable?: boolean;
+}
+
+/**
+ * Operation lifecycle event used to surface authoritative retry/failure status.
+ */
+export interface OperationStatusEvent extends StreamEventBase {
+    type: 'operation_status';
+    operation: 'request' | 'image' | 'result';
+    status: 'started' | 'retrying' | 'failed' | 'completed';
+    error?: string;
+    reason?: string;
+    recoverable?: boolean;
+    terminal?: boolean;
+    will_continue?: boolean;
+    attempt?: number;
+    max_attempts?: number;
 }
 
 /**
@@ -450,6 +471,7 @@ export type ProviderStreamEvent =
     | FileEvent
     | ToolEvent
     | ErrorEvent
+    | OperationStatusEvent
     | CostUpdateEvent
     | ResponseOutputEvent
     | AgentEvent;
@@ -884,6 +906,9 @@ export interface ImageGenerationOpts {
 
     /** Background transparency */
     background?: 'transparent' | 'opaque' | 'auto';
+
+    /** Optional timeout for the overall image operation, including provider SDK stalls */
+    timeout_ms?: number;
 
     /** Control how closely the output matches the input image (OpenAI experimental) */
     input_fidelity?: 'low' | 'medium' | 'high';

--- a/utils/ensemble_result.ts
+++ b/utils/ensemble_result.ts
@@ -10,7 +10,9 @@ import {
     ResponseInputItem,
     ToolCallResult,
     AgentExportDefinition,
+    OperationStatusEvent,
 } from '../types/types.js';
+import { getEventError, isTerminalFailureEvent } from './failure_detection.js';
 
 /**
  * Result object containing all aggregated data from an ensemble stream
@@ -50,6 +52,16 @@ export interface EnsembleResult {
     /** Any errors that occurred */
     error?: string;
 
+    /** Structured failure metadata when the stream reports an authoritative failure */
+    failure?: {
+        operation?: 'request' | 'image' | 'result';
+        request_id?: string;
+        reason?: string;
+        terminal: boolean;
+        recoverable: boolean;
+        detectedAt: Date;
+    };
+
     /** All response output messages */
     responseOutputs?: ResponseInputItem[];
 
@@ -69,12 +81,23 @@ export interface EnsembleResult {
     messageIds: Set<string>;
 }
 
+export interface EnsembleResultOptions {
+    /**
+     * Stop consuming the stream as soon as a terminal failure is reported.
+     * This allows callers to retry immediately instead of waiting for stream_end.
+     */
+    failFast?: boolean;
+}
+
 /**
  * Converts an ensemble stream into a single result object
  * @param stream - The async generator stream from ensembleRequest or similar
  * @returns Promise resolving to the aggregated result
  */
-export async function ensembleResult(stream: AsyncGenerator<ProviderStreamEvent>): Promise<EnsembleResult> {
+export async function ensembleResult(
+    stream: AsyncGenerator<ProviderStreamEvent>,
+    options: EnsembleResultOptions = {}
+): Promise<EnsembleResult> {
     const result: EnsembleResult = {
         message: '',
         completed: false,
@@ -88,6 +111,53 @@ export async function ensembleResult(stream: AsyncGenerator<ProviderStreamEvent>
     const toolCalls = new Map<string, ToolCallResult>();
     const files: EnsembleResult['files'] = [];
     const responseOutputs: ResponseInputItem[] = [];
+    const finalizeAggregates = () => {
+        if (!result.message && messageDeltas.size > 0) {
+            const allDeltas: string[] = [];
+            for (const deltas of messageDeltas.values()) {
+                allDeltas.push(...deltas);
+            }
+            result.message = allDeltas.join('');
+        }
+
+        if (toolCalls.size > 0) {
+            result.tools = {
+                calls: Array.from(toolCalls.values()),
+                totalCalls: toolCalls.size,
+            };
+        }
+
+        if (files.length > 0) {
+            result.files = files;
+        }
+
+        if (responseOutputs.length > 0) {
+            result.responseOutputs = responseOutputs;
+        }
+    };
+    const consumeImmediateFollowupEvent = async (): Promise<ProviderStreamEvent | undefined> => {
+        const sentinel = Symbol('no_immediate_followup');
+        const nextEventPromise = stream.next();
+        const nextIteration = await Promise.race([
+            nextEventPromise,
+            new Promise<typeof sentinel>(resolve => {
+                setTimeout(() => resolve(sentinel), 0);
+            }),
+        ]);
+
+        if (nextIteration === sentinel) {
+            nextEventPromise.catch(() => {
+                // Ignore the follow-up event if failFast returns before it resolves.
+            });
+            return undefined;
+        }
+
+        if (nextIteration.done) {
+            return undefined;
+        }
+
+        return nextIteration.value;
+    };
 
     try {
         for await (const event of stream) {
@@ -133,13 +203,13 @@ export async function ensembleResult(stream: AsyncGenerator<ProviderStreamEvent>
                         }
 
                         // Handle thinking content
-                        if (thinkingDeltas.has(msgEvent.message_id)) {
-                            const thinking = thinkingDeltas.get(msgEvent.message_id)!;
+                        const thinking = thinkingDeltas.get(msgEvent.message_id);
+                        if (msgEvent.thinking_content || msgEvent.thinking_signature || thinking) {
                             result.thinking = {
-                                content: msgEvent.thinking_content || thinking.content.join(''),
+                                content: msgEvent.thinking_content || thinking?.content.join('') || '',
                                 signature:
                                     msgEvent.thinking_signature ||
-                                    (thinking.signature?.length ? thinking.signature.join('') : undefined),
+                                    (thinking?.signature?.length ? thinking.signature.join('') : undefined),
                             };
                         }
                     }
@@ -198,6 +268,89 @@ export async function ensembleResult(stream: AsyncGenerator<ProviderStreamEvent>
                 case 'error': {
                     const errorEvent = event as ErrorEvent;
                     result.error = errorEvent.error;
+
+                    if (isTerminalFailureEvent(event)) {
+                        const hadAuthoritativeFailure =
+                            result.failure?.operation !== undefined && result.failure.operation !== 'result';
+
+                        result.failure = {
+                            operation: result.failure?.operation ?? 'result',
+                            request_id: errorEvent.request_id ?? result.failure?.request_id,
+                            reason: result.failure?.reason,
+                            terminal: true,
+                            recoverable: false,
+                            detectedAt: result.failure?.detectedAt ?? new Date(),
+                        };
+
+                        if (options.failFast) {
+                            if (!hadAuthoritativeFailure) {
+                                const followupEvent = await consumeImmediateFollowupEvent();
+                                if (followupEvent?.type === 'operation_status') {
+                                    const statusEvent = followupEvent as OperationStatusEvent;
+                                    if (statusEvent.status === 'failed') {
+                                        const eventError = getEventError(followupEvent);
+                                        if (eventError) {
+                                            result.error = eventError;
+                                        }
+
+                                        result.failure = {
+                                            operation: statusEvent.operation,
+                                            request_id: statusEvent.request_id,
+                                            reason: statusEvent.reason,
+                                            terminal: statusEvent.terminal === true,
+                                            recoverable: statusEvent.recoverable === true,
+                                            detectedAt: new Date(),
+                                        };
+                                    }
+                                }
+                            }
+
+                            await stream.return(undefined);
+                            finalizeAggregates();
+                            result.completed = false;
+                            result.endTime = new Date();
+                            return result;
+                        }
+                    }
+                    break;
+                }
+
+                case 'operation_status': {
+                    const statusEvent = event as OperationStatusEvent;
+
+                    if (statusEvent.status === 'failed') {
+                        const eventError = getEventError(event);
+                        if (eventError) {
+                            result.error = eventError;
+                        }
+                    }
+
+                    if (statusEvent.status === 'failed') {
+                        result.failure = {
+                            operation: statusEvent.operation,
+                            request_id: statusEvent.request_id,
+                            reason: statusEvent.reason,
+                            terminal: statusEvent.terminal === true,
+                            recoverable: statusEvent.recoverable === true,
+                            detectedAt: new Date(),
+                        };
+
+                        if (options.failFast && statusEvent.terminal) {
+                            await stream.return(undefined);
+                            finalizeAggregates();
+                            result.completed = false;
+                            result.endTime = new Date();
+                            return result;
+                        }
+                    }
+
+                    if (statusEvent.status === 'completed') {
+                        if (!result.failure || result.failure.terminal !== true) {
+                            result.error = undefined;
+                            result.failure = undefined;
+                        }
+                    }
+
                     break;
                 }
 
@@ -216,41 +369,18 @@ export async function ensembleResult(stream: AsyncGenerator<ProviderStreamEvent>
                 }
 
                 case 'stream_end': {
-                    result.completed = true;
+                    if (result.failure?.terminal !== true) {
+                        result.completed = true;
+                    }
                     break;
                 }
             }
         }
 
-        // If no message_complete was received, join all deltas
-        if (!result.message && messageDeltas.size > 0) {
-            const allDeltas: string[] = [];
-            for (const deltas of messageDeltas.values()) {
-                allDeltas.push(...deltas);
-            }
-            result.message = allDeltas.join('');
-        }
+        finalizeAggregates();
 
-        // Add tools if any were called
-        if (toolCalls.size > 0) {
-            result.tools = {
-                calls: Array.from(toolCalls.values()),
-                totalCalls: toolCalls.size,
-            };
-        }
-
-        // Add files if any were received
-        if (files.length > 0) {
-            result.files = files;
-        }
-
-        // Add response outputs if any
-        if (responseOutputs.length > 0) {
-            result.responseOutputs = responseOutputs;
-        }
-
-        // Mark as completed if we finished the loop without errors
-        if (!result.error && !result.completed) {
+        // Mark as completed only when the stream ended without terminal failures or recorded errors.
+        if (!result.completed && result.failure?.terminal !== true && result.error === undefined) {
             result.completed = true;
         }
     } catch (error) {

--- a/utils/failure_detection.ts
+++ b/utils/failure_detection.ts
@@ -1,0 +1,182 @@
+import type { ErrorEvent, OperationStatusEvent, ProviderStreamEvent } from '../types/types.js';
+
+function createGuardError(operationName: string, kind: 'aborted' | 'timed_out', timeoutMs?: number): Error {
+    const error = new Error(
+        kind === 'aborted' ? `${operationName} aborted` : `${operationName} timed out after ${timeoutMs}ms`
+    ) as Error & {
+        code?: string;
+        recoverable?: boolean;
+    };
+
+    error.code = kind === 'aborted' ? 'ABORT_ERR' : 'ETIMEDOUT';
+    error.recoverable = false;
+    if (kind === 'aborted') {
+        error.name = 'AbortError';
+    }
+
+    return error;
+}
+
+export function createOperationStatusEvent(
+    event: Omit<OperationStatusEvent, 'type' | 'timestamp'>
+): OperationStatusEvent {
+    return {
+        type: 'operation_status',
+        timestamp: new Date().toISOString(),
+        ...event,
+    };
+}
+
+export function isTerminalFailureEvent(event: ProviderStreamEvent): boolean {
+    if (event.type === 'operation_status') {
+        const statusEvent = event as OperationStatusEvent;
+        return statusEvent.status === 'failed' && statusEvent.terminal === true;
+    }
+
+    if (event.type === 'error') {
+        const errorEvent = event as ErrorEvent;
+        return errorEvent.recoverable === false;
+    }
+
+    return false;
+}
+
+export function getEventError(event: ProviderStreamEvent): string | undefined {
+    if (event.type === 'operation_status' || event.type === 'error') {
+        return (event as OperationStatusEvent | ErrorEvent).error;
+    }
+
+    return undefined;
+}
+
+export function toTerminalErrorEvent(
+    event: Omit<ErrorEvent, 'type' | 'timestamp' | 'recoverable'> & { recoverable?: boolean }
+): ErrorEvent {
+    return {
+        type: 'error',
+        timestamp: new Date().toISOString(),
+        ...event,
+        recoverable: event.recoverable ?? false,
+    };
+}
+
+export async function raceWithAbortAndTimeout<T>(
+    operation: Promise<T> | (() => Promise<T>),
+    options: {
+        operationName: string;
+        abortSignal?: AbortSignal;
+        timeoutMs?: number;
+    }
+): Promise<T> {
+    const { operationName, abortSignal, timeoutMs } = options;
+
+    if (abortSignal?.aborted) {
+        throw createGuardError(operationName, 'aborted');
+    }
+
+    let abortListener: (() => void) | undefined;
+    let timeoutId: NodeJS.Timeout | undefined;
+
+    const guardPromise = new Promise<T>((_, reject) => {
+        if (abortSignal) {
+            abortListener = () => reject(createGuardError(operationName, 'aborted'));
+            abortSignal.addEventListener('abort', abortListener, { once: true });
+        }
+
+        if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+            timeoutId = setTimeout(() => {
+                reject(createGuardError(operationName, 'timed_out', timeoutMs));
+            }, timeoutMs);
+        }
+    });
+
+    const operationPromise =
+        typeof operation === 'function'
+            ? Promise.resolve().then(() => operation())
+            : operation;
+
+    try {
+        return await Promise.race([operationPromise, guardPromise]);
+    } finally {
+        if (abortSignal && abortListener) {
+            abortSignal.removeEventListener('abort', abortListener);
+        }
+
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+
+        operationPromise.catch(() => {
+            // Ignore the eventual provider rejection if the guard won the race.
+        });
+    }
+}
+
+export async function* streamWithAbortAndTimeout<T>(
+    stream: AsyncGenerator<T>,
+    options: {
+        operationName: string;
+        abortSignal?: AbortSignal;
+        timeoutMs?: number;
+    }
+): AsyncGenerator<T> {
+    const { operationName, abortSignal, timeoutMs } = options;
+
+    if (abortSignal?.aborted) {
+        throw createGuardError(operationName, 'aborted');
+    }
+
+    let abortListener: (() => void) | undefined;
+    let timeoutId: NodeJS.Timeout | undefined;
+    let streamCompleted = false;
+
+    const guardPromise = new Promise<IteratorResult<T>>((_, reject) => {
+        if (abortSignal) {
+            abortListener = () => reject(createGuardError(operationName, 'aborted'));
+            abortSignal.addEventListener('abort', abortListener, { once: true });
+        }
+
+        if (typeof timeoutMs === 'number' && timeoutMs > 0) {
+            timeoutId = setTimeout(() => {
+                reject(createGuardError(operationName, 'timed_out', timeoutMs));
+            }, timeoutMs);
+        }
+    });
+
+    try {
+        while (true) {
+            const nextPromise = stream.next();
+            let iteration: IteratorResult<T>;
+
+            try {
+                iteration = await Promise.race([nextPromise, guardPromise]);
+            } catch (error) {
+                nextPromise.catch(() => {
+                    // Ignore the eventual provider rejection if the guard won the race.
+                });
+                throw error;
+            }
+
+            if (iteration.done) {
+                streamCompleted = true;
+                return;
+            }
+
+            yield iteration.value;
+        }
+    } finally {
+        if (abortSignal && abortListener) {
+            abortSignal.removeEventListener('abort', abortListener);
+        }
+
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+
+        if (!streamCompleted && typeof stream.return === 'function') {
+            void stream.return(undefined).catch(() => {
+                // Ignore cleanup failures from provider iterators.
+            });
+        }
+    }
+}

--- a/utils/json_schema.ts
+++ b/utils/json_schema.ts
@@ -1,0 +1,581 @@
+import type { ToolParameter } from '../types/types.js';
+
+type ValidationResult = {
+    ok: boolean;
+    error?: string;
+};
+
+function describePath(path: string): string {
+    return path === '$' ? 'response' : path;
+}
+
+function joinPath(path: string, segment: string | number): string {
+    return typeof segment === 'number' ? `${path}[${segment}]` : `${path}.${segment}`;
+}
+
+function getAllowedTypes(schema: any): string[] {
+    if (typeof schema?.type === 'string') {
+        return [schema.type];
+    }
+    if (Array.isArray(schema?.type)) {
+        return schema.type.filter((type: unknown): type is string => typeof type === 'string');
+    }
+    return [];
+}
+
+function matchesType(value: unknown, type: string): boolean {
+    switch (type) {
+        case 'array':
+            return Array.isArray(value);
+        case 'object':
+            return value !== null && typeof value === 'object' && !Array.isArray(value);
+        case 'string':
+            return typeof value === 'string';
+        case 'number':
+            return typeof value === 'number' && Number.isFinite(value);
+        case 'integer':
+            return typeof value === 'number' && Number.isInteger(value);
+        case 'boolean':
+            return typeof value === 'boolean';
+        case 'null':
+            return value === null;
+        default:
+            return true;
+    }
+}
+
+function areJsonValuesEqual(left: unknown, right: unknown): boolean {
+    if (left === right) {
+        return true;
+    }
+
+    if (left === null || right === null) {
+        return left === right;
+    }
+
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+            return false;
+        }
+
+        return left.every((entry, index) => areJsonValuesEqual(entry, right[index]));
+    }
+
+    if (typeof left === 'object' && typeof right === 'object') {
+        const leftRecord = left as Record<string, unknown>;
+        const rightRecord = right as Record<string, unknown>;
+        const leftKeys = Object.keys(leftRecord);
+        const rightKeys = Object.keys(rightRecord);
+
+        if (leftKeys.length !== rightKeys.length) {
+            return false;
+        }
+
+        return leftKeys.every(key => key in rightRecord && areJsonValuesEqual(leftRecord[key], rightRecord[key]));
+    }
+
+    return false;
+}
+
+function getObjectProperties(schema: any): Record<string, unknown> | undefined {
+    return schema?.properties && typeof schema.properties === 'object'
+        ? (schema.properties as Record<string, unknown>)
+        : undefined;
+}
+
+function getRequiredPropertiesForValidation(schema: any, properties?: Record<string, unknown>): string[] {
+    if (Array.isArray(schema?.required)) {
+        return schema.required.filter((entry: unknown): entry is string => typeof entry === 'string');
+    }
+
+    return [];
+}
+
+function collectAllowedObjectKeys(value: Record<string, unknown>, schema: any, path: string): Set<string> {
+    const allowedKeys = new Set<string>();
+    const properties = getObjectProperties(schema);
+
+    if (properties) {
+        for (const key of Object.keys(properties)) {
+            allowedKeys.add(key);
+        }
+    }
+
+    if (Array.isArray(schema?.anyOf)) {
+        for (const candidate of schema.anyOf) {
+            if (!validateAgainstSchema(value, candidate, path).ok) {
+                continue;
+            }
+            for (const key of collectAllowedObjectKeys(value, candidate, path)) {
+                allowedKeys.add(key);
+            }
+        }
+    }
+
+    if (Array.isArray(schema?.oneOf)) {
+        for (const candidate of schema.oneOf) {
+            if (!validateAgainstSchema(value, candidate, path).ok) {
+                continue;
+            }
+            for (const key of collectAllowedObjectKeys(value, candidate, path)) {
+                allowedKeys.add(key);
+            }
+        }
+    }
+
+    if (Array.isArray(schema?.allOf)) {
+        for (const candidate of schema.allOf) {
+            for (const key of collectAllowedObjectKeys(value, candidate, path)) {
+                allowedKeys.add(key);
+            }
+        }
+    }
+
+    return allowedKeys;
+}
+
+function shouldTreatAllOfObjectAsClosed(schema: any): boolean {
+    if (schema?.additionalProperties === false) {
+        return true;
+    }
+
+    if (!Array.isArray(schema?.allOf)) {
+        return false;
+    }
+
+    const objectBranches = schema.allOf.filter((candidate: unknown) => {
+        if (!candidate || typeof candidate !== 'object') {
+            return false;
+        }
+
+        const objectCandidate = candidate as Record<string, unknown>;
+        return objectCandidate.type === 'object' || typeof objectCandidate.properties === 'object';
+    });
+
+    return objectBranches.length > 0 && objectBranches.every((candidate: any) => candidate?.additionalProperties === false);
+}
+
+function shouldRelaxAllOfObjectBranches(schema: any): boolean {
+    if (!Array.isArray(schema?.allOf)) {
+        return false;
+    }
+
+    const objectBranches = schema.allOf.filter((candidate: unknown) => {
+        if (!candidate || typeof candidate !== 'object') {
+            return false;
+        }
+
+        const objectCandidate = candidate as Record<string, unknown>;
+        return objectCandidate.type === 'object' || typeof objectCandidate.properties === 'object';
+    });
+
+    return objectBranches.length > 0 && objectBranches.every((candidate: any) => candidate?.additionalProperties === false);
+}
+
+function relaxAllOfObjectBranch(candidate: any): any {
+    if (!candidate || typeof candidate !== 'object') {
+        return candidate;
+    }
+
+    if (candidate.additionalProperties !== false) {
+        return candidate;
+    }
+
+    return {
+        ...candidate,
+        additionalProperties: undefined,
+    };
+}
+
+function isValidMultipleOf(value: number, step: number): boolean {
+    if (!Number.isFinite(step) || step <= 0) {
+        return true;
+    }
+
+    const quotient = value / step;
+    const roundedQuotient = Math.round(quotient);
+    const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient)) * 16;
+
+    return Math.abs(quotient - roundedQuotient) <= tolerance;
+}
+
+function validateAgainstSchema(value: unknown, schema: any, path = '$'): ValidationResult {
+    if (!schema || typeof schema !== 'object') {
+        return { ok: true };
+    }
+
+    if (schema.const !== undefined && !areJsonValuesEqual(value, schema.const)) {
+        return {
+            ok: false,
+            error: `${describePath(path)} must equal ${JSON.stringify(schema.const)}`,
+        };
+    }
+
+    if (Array.isArray(schema.enum) && !schema.enum.some((entry: unknown) => areJsonValuesEqual(entry, value))) {
+        return {
+            ok: false,
+            error: `${describePath(path)} must be one of ${schema.enum.map((entry: unknown) => JSON.stringify(entry)).join(', ')}`,
+        };
+    }
+
+    const allowedTypes = getAllowedTypes(schema);
+    if (allowedTypes.length > 0 && !allowedTypes.some(type => matchesType(value, type))) {
+        return {
+            ok: false,
+            error: `${describePath(path)} must be ${allowedTypes.join(' or ')}`,
+        };
+    }
+
+    if (Array.isArray(schema.anyOf)) {
+        const anyOfValid = schema.anyOf.some((candidate: unknown) => validateAgainstSchema(value, candidate, path).ok);
+        if (!anyOfValid) {
+            return {
+                ok: false,
+                error: `${describePath(path)} did not match any allowed schema variant`,
+            };
+        }
+    }
+
+    if (Array.isArray(schema.oneOf)) {
+        const matches = schema.oneOf.filter((candidate: unknown) => validateAgainstSchema(value, candidate, path).ok).length;
+        if (matches !== 1) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must match exactly one schema variant`,
+            };
+        }
+    }
+
+    const relaxAllOfObjectBranches = shouldRelaxAllOfObjectBranches(schema);
+    if (Array.isArray(schema.allOf)) {
+        for (const candidate of schema.allOf) {
+            const candidateSchema =
+                relaxAllOfObjectBranches && value !== null && typeof value === 'object' && !Array.isArray(value)
+                    ? relaxAllOfObjectBranch(candidate)
+                    : candidate;
+            const result = validateAgainstSchema(value, candidateSchema, path);
+            if (!result.ok) {
+                return result;
+            }
+        }
+    }
+
+    if (typeof value === 'string') {
+        if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must be at least ${schema.minLength} characters`,
+            };
+        }
+        if (typeof schema.maxLength === 'number' && value.length > schema.maxLength) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must be at most ${schema.maxLength} characters`,
+            };
+        }
+        if (typeof schema.pattern === 'string') {
+            let regex: RegExp;
+            try {
+                regex = new RegExp(schema.pattern);
+            } catch (error) {
+                return {
+                    ok: false,
+                    error: `${describePath(path)} uses invalid pattern ${schema.pattern}: ${error instanceof Error ? error.message : String(error)}`,
+                };
+            }
+            if (!regex.test(value)) {
+                return {
+                    ok: false,
+                    error: `${describePath(path)} must match pattern ${schema.pattern}`,
+                };
+            }
+        }
+    }
+
+    if (typeof value === 'number') {
+        if (typeof schema.minimum === 'number' && value < schema.minimum) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must be >= ${schema.minimum}`,
+            };
+        }
+        if (typeof schema.maximum === 'number' && value > schema.maximum) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must be <= ${schema.maximum}`,
+            };
+        }
+        if (typeof schema.multipleOf === 'number' && !isValidMultipleOf(value, schema.multipleOf)) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must be a multiple of ${schema.multipleOf}`,
+            };
+        }
+    }
+
+    if (Array.isArray(value)) {
+        if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must contain at least ${schema.minItems} items`,
+            };
+        }
+        if (typeof schema.maxItems === 'number' && value.length > schema.maxItems) {
+            return {
+                ok: false,
+                error: `${describePath(path)} must contain at most ${schema.maxItems} items`,
+            };
+        }
+        if (schema.items) {
+            for (const [index, item] of value.entries()) {
+                const itemSchema = Array.isArray(schema.items) ? schema.items[index] : schema.items;
+
+                if (itemSchema === undefined) {
+                    if (schema.additionalItems === false) {
+                        return {
+                            ok: false,
+                            error: `${describePath(joinPath(path, index))} is not allowed`,
+                        };
+                    }
+
+                    if (schema.additionalItems && typeof schema.additionalItems === 'object') {
+                        const result = validateAgainstSchema(item, schema.additionalItems, joinPath(path, index));
+                        if (!result.ok) {
+                            return result;
+                        }
+                    }
+                    continue;
+                }
+
+                const result = validateAgainstSchema(item, itemSchema, joinPath(path, index));
+                if (!result.ok) {
+                    return result;
+                }
+            }
+        }
+    }
+
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        const objectValue = value as Record<string, unknown>;
+        const properties = getObjectProperties(schema);
+        const required = getRequiredPropertiesForValidation(schema, properties);
+
+        for (const key of required) {
+            if (!(key in objectValue)) {
+                return {
+                    ok: false,
+                    error: `${describePath(joinPath(path, key))} is required`,
+                };
+            }
+        }
+
+        if (properties) {
+            for (const [key, childSchema] of Object.entries(properties)) {
+                if (!(key in objectValue)) {
+                    continue;
+                }
+                const result = validateAgainstSchema(objectValue[key], childSchema, joinPath(path, key));
+                if (!result.ok) {
+                    return result;
+                }
+            }
+        }
+
+        const allowedKeys = collectAllowedObjectKeys(objectValue, schema, path);
+        const isClosedObject = shouldTreatAllOfObjectAsClosed(schema);
+        for (const key of Object.keys(objectValue)) {
+            if (allowedKeys.has(key)) {
+                continue;
+            }
+
+            if (isClosedObject) {
+                return {
+                    ok: false,
+                    error: `${describePath(joinPath(path, key))} is not allowed`,
+                };
+            }
+
+            if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+                const result = validateAgainstSchema(objectValue[key], schema.additionalProperties, joinPath(path, key));
+                if (!result.ok) {
+                    return result;
+                }
+            }
+        }
+    }
+
+    return { ok: true };
+}
+
+/**
+ * Process a JSON schema to make it compatible with OpenAI's strict JSON mode.
+ */
+function deriveRequiredProperties(
+    sourceSchema: any,
+    propertyNames: string[],
+    mode: 'tool_parameters' | 'json_schema'
+): string[] | undefined {
+    if (!sourceSchema?.properties || typeof sourceSchema.properties !== 'object') {
+        return undefined;
+    }
+
+    if (mode === 'tool_parameters') {
+        if (Array.isArray(sourceSchema.required)) {
+            const explicitlyRequired = new Set(sourceSchema.required);
+            return propertyNames.filter(name => explicitlyRequired.has(name));
+        }
+
+        return propertyNames.filter(name => sourceSchema.properties?.[name]?.optional !== true);
+    }
+
+    return propertyNames;
+}
+
+export function processSchemaForOpenAI(
+    schema: any,
+    originalProperties?: Record<string, ToolParameter>,
+    mode: 'tool_parameters' | 'json_schema' = 'tool_parameters'
+): any {
+    const processedSchema = JSON.parse(JSON.stringify(schema));
+
+    const processSchemaRecursively = (currentSchema: any, sourceSchema?: any) => {
+        if (!currentSchema || typeof currentSchema !== 'object') return;
+
+        if (currentSchema.optional === true) {
+            delete currentSchema.optional;
+        }
+
+        if (Array.isArray(currentSchema.oneOf)) {
+            currentSchema.anyOf = currentSchema.oneOf;
+            delete currentSchema.oneOf;
+        }
+
+        const variantSourceSchemas = {
+            anyOf: sourceSchema?.anyOf ?? sourceSchema?.oneOf,
+            allOf: sourceSchema?.allOf,
+        };
+
+        const unsupportedKeywords = [
+            'minimum',
+            'maximum',
+            'minItems',
+            'maxItems',
+            'minLength',
+            'maxLength',
+            'pattern',
+            'format',
+            'multipleOf',
+            'patternProperties',
+            'unevaluatedProperties',
+            'propertyNames',
+            'minProperties',
+            'maxProperties',
+            'unevaluatedItems',
+            'contains',
+            'minContains',
+            'maxContains',
+            'uniqueItems',
+            'default',
+        ];
+        unsupportedKeywords.forEach(keyword => {
+            if (currentSchema[keyword] !== undefined) {
+                delete currentSchema[keyword];
+            }
+        });
+
+        const isObject =
+            currentSchema.type === 'object' ||
+            (currentSchema.type === undefined && currentSchema.properties !== undefined);
+
+        for (const key of ['anyOf', 'allOf'] as const) {
+            if (Array.isArray(currentSchema[key])) {
+                currentSchema[key].forEach((variantSchema: any, index: number) =>
+                    processSchemaRecursively(variantSchema, variantSourceSchemas[key]?.[index])
+                );
+            }
+        }
+
+        if (isObject && currentSchema.properties) {
+            for (const propName in currentSchema.properties) {
+                processSchemaRecursively(currentSchema.properties[propName], sourceSchema?.properties?.[propName]);
+            }
+        }
+
+        if (currentSchema.type === 'array' && currentSchema.items !== undefined) {
+            if (Array.isArray(currentSchema.items)) {
+                currentSchema.items.forEach((itemSchema: any, index: number) =>
+                    processSchemaRecursively(itemSchema, sourceSchema?.items?.[index])
+                );
+            } else if (typeof currentSchema.items === 'object') {
+                processSchemaRecursively(currentSchema.items, sourceSchema?.items);
+            }
+        }
+
+        if (isObject) {
+            currentSchema.additionalProperties = false;
+            if (currentSchema.properties) {
+                const currentRequired = deriveRequiredProperties(
+                    sourceSchema,
+                    Object.keys(currentSchema.properties),
+                    mode
+                );
+                if (currentRequired && currentRequired.length > 0) {
+                    currentSchema.required = currentRequired;
+                } else {
+                    delete currentSchema.required;
+                }
+            } else {
+                delete currentSchema.required;
+            }
+        }
+    };
+
+    processSchemaRecursively(processedSchema, schema);
+
+    if (mode === 'tool_parameters' && originalProperties && !Array.isArray(schema?.required)) {
+        const topLevelRequired = deriveRequiredProperties(
+            { properties: originalProperties, required: schema?.required },
+            Object.keys(originalProperties),
+            mode
+        );
+        if (topLevelRequired && topLevelRequired.length > 0) {
+            processedSchema.required = topLevelRequired;
+        } else {
+            delete processedSchema.required;
+        }
+    }
+
+    if (processedSchema.properties && processedSchema.additionalProperties === undefined) {
+        processedSchema.additionalProperties = false;
+    }
+
+    return processedSchema;
+}
+
+export function validateJsonResponseContent(
+    content: string,
+    schema?: Record<string, unknown>
+): { ok: true; value: unknown } | { ok: false; error: string } {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(content);
+    } catch (error) {
+        return {
+            ok: false,
+            error: `Structured output was not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+        };
+    }
+
+    if (schema) {
+        const validation = validateAgainstSchema(parsed, schema);
+        if (!validation.ok) {
+            return {
+                ok: false,
+                error: `Structured output failed schema validation: ${validation.error}`,
+            };
+        }
+    }
+
+    return { ok: true, value: parsed };
+}

--- a/utils/message_converter.ts
+++ b/utils/message_converter.ts
@@ -83,7 +83,7 @@ export function convertToFunctionCallOutput(
         type: 'function_call_output',
         call_id: toolResult.call_id || toolResult.toolCall.id,
         name: toolResult.toolCall.function.name,
-        output: toolResult.output + (toolResult.error || ''),
+        output: (toolResult.output || '') + (toolResult.error || ''),
         model,
         status,
         timestamp: Date.now(),


### PR DESCRIPTION
## Summary
- add shared operation lifecycle events and abort/timeout guards for request and image flows
- make provider malformed-tool and structured-output failures terminal instead of silently coercing them
- add fail-fast result aggregation, schema validation helpers, docs, and focused regression coverage

## Testing
- npx vitest run test/failure_detection.test.ts test/provider_chat_failure_paths.test.ts test/provider_image_failure_paths.test.ts
- npm run build