### PR TITLE
fix(demo): update react-router for Dependabot alert 101

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -4120,9 +4120,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4142,12 +4142,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"


### PR DESCRIPTION
Fixes Dependabot alert 101 / GHSA-8x6r-g9mw-2r78 by refreshing the demo lockfile so react-router resolves to 7.16.0.\n\nValidation run in isolated clone /tmp/justevery-maintenance/2026-06-04-ensemble-dependabot-101:\n- npm update react-router-dom --package-lock-only --prefix demo\n- npm install --prefix demo\n- npm ls react-router react-router-dom --package-lock-only --prefix demo\n- npm audit --prefix demo --omit=dev --json (targeted react-router advisory no longer present; unrelated existing advisories remain)\n- npm install\n- npm run lint:fix\n- npm run test\n- npm run build\n\nKnown unrelated validation note:\n- npm run build --prefix demo still fails on existing missing NodeJS namespace typings in demo source files, not on react-router.